### PR TITLE
Fix the failed v0.3.0 release: bump the workspace version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v0.3.0] - Unreleased
+## [v0.3.0] - 2026-08-02
 
 ### 🚀 New Features & Enhancements
 - **Automated Release Pipeline**: Added `cargo-dist` configuration and a GitHub Actions workflow that builds and publishes Linux and Windows binaries, with shell and PowerShell installers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ac_core"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "ac_tui"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "ac_core",
  "anyhow",
@@ -1663,7 +1663,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shm-bridge"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "tests_suite"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "ac_core",
  "ac_tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["core", "tui", "shm-bridge", "tests_suite"]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.3.0"
 edition = "2024"
 authors = ["Rgosh"]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "ac_core"
 description = "Core telemetry and setup logic for AC Pro Engineer"
-version = "0.2.3"
+# Must track the workspace: `updater::CURRENT_VERSION` is this crate's
+# CARGO_PKG_VERSION, and it is what the app reports as its own version and
+# compares release tags against.
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 

--- a/tests_suite/Cargo.toml
+++ b/tests_suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tests_suite"
-version = "0.2.3"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/tests_suite/src/core_tests.rs
+++ b/tests_suite/src/core_tests.rs
@@ -790,3 +790,22 @@ fn test_43_ghost_delta_calculation() {
     assert!(delta.is_some());
     assert!((delta.unwrap() - 1.5).abs() < 0.01);
 }
+
+/// `updater::CURRENT_VERSION` is `ac_core`'s own `CARGO_PKG_VERSION`, and it is
+/// what the app displays, what Discord rich presence reports, and what release
+/// tags are compared against to decide whether an update is newer.
+///
+/// When `ac_core` carried a hardcoded version it silently fell behind the
+/// workspace: a build tagged v0.3.0 would have reported itself as 0.2.3, seen
+/// its own release as an upgrade, installed it, and offered it again forever.
+/// This pins the crate to the workspace version — `tests_suite` inherits it, so
+/// the two only agree while `core/Cargo.toml` says `version.workspace = true`.
+#[test]
+fn core_version_tracks_the_workspace_version() {
+    assert_eq!(
+        ac_core::updater::CURRENT_VERSION,
+        env!("CARGO_PKG_VERSION"),
+        "ac_core has drifted from the workspace version; \
+         core/Cargo.toml must use `version.workspace = true`"
+    );
+}


### PR DESCRIPTION
The `v0.3.0` tag's Release run ([30720369922](https://github.com/Rgosh/ac-pro-engineer/actions/runs/30720369922)) failed in the `plan` job:

```
dist host --steps=create --tag=v0.3.0
× This workspace doesn't have anything for dist to Release!
help: You may need to pass the current version as --tag, or need to give all
      your packages the same version
      --tag=v0.2.3 will Announce: ac_tui, shm-bridge
```

dist matches the tag's version against the packages it can release. The tag was cut from a tree where only the CHANGELOG heading had been bumped — every package was still `0.2.3`. Nothing was published: the run died before the release was created, and there is no `v0.3.0` release or asset upstream.

## The fix

`[workspace.package].version` → `0.3.0`, which covers `ac_tui` and `shm-bridge` — the two packages dist announces.

## The part that would have bitten later

`ac_core` and `tests_suite` were pinning `0.2.3` by hand rather than inheriting the workspace version. `ac_core`'s is the one that matters:

```rust
// core/src/updater.rs
pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");  // ac_core's version
```

That constant is what the launcher displays (4 call sites), what Discord rich presence reports, what `config.last_run_version` is compared against, and — the important one — what decides whether a release tag is newer than the running build:

```rust
if compare_semver(remote_ver_str, CURRENT_VERSION) == Ordering::Less { continue; }
```

Bumping only `[workspace.package]` would have made the release succeed while shipping a **v0.3.0 build that reports itself as 0.2.3**. It would see its own release as an upgrade, install it, restart, still report 0.2.3, and offer the same update again — a loop that only ends when the user stops clicking.

Both crates now inherit the workspace version. `tests_suite` inherits it too, so a test there pins the invariant:

```rust
assert_eq!(ac_core::updater::CURRENT_VERSION, env!("CARGO_PKG_VERSION"));
```

The two only agree while `core/Cargo.toml` says `version.workspace = true`, so the next bump cannot silently reintroduce the drift.

Also dates the CHANGELOG entry, which still read `Unreleased`.

## Verification

- `dist plan --tag=v0.3.0` — announces `ac_tui 0.3.0` and `shm-bridge 0.3.0` with the expected artifacts (previously the hard error above)
- `dist generate --mode=ci --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0 on `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-gnu`
- `cargo fmt --all --check` — clean
- `cargo test --workspace` — 109 passed, 0 failed

## After merging

The `v0.3.0` tag currently points at the merge commit of #3, which cannot be released. It needs to move to the commit that lands this PR:

```
git push upstream :refs/tags/v0.3.0
git tag v0.3.0 <merge-commit> && git push upstream v0.3.0
```

Safe to move: no release or assets were ever published under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
