### PR TITLE
fix(shm): use AC's graphics layout, not ACC's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### 🛡️ Bug Fixes & Stability
 - **Shared-Memory Graphics Layout**: `AcGraphics` was using Assetto Corsa Competizione's `SPageFileGraphic` layout, which carries `activeCars`, `carCoordinates[60][3]`, `carID[60]`, `playerCarID` and `penalty` — 964 bytes that plain AC never writes. Every field from `car_coordinates` onward was therefore read from the wrong offset, past the end of the 360-byte page AC actually publishes. Track position was plotted from the car's altitude, and `surface_grip`, `fuel_x_lap`, `wind_speed`, `tc`, `abs`, `engine_map`, `flag` and the driver-stint timers all read a constant zero. Reported in [#2](https://github.com/Rgosh/ac-pro-engineer/issues/2).
-- **Shared-Memory Regression Tests**: Added layout tests that parse a page captured verbatim from a live AC 1.16.4 session through the same zerocopy call the app uses. Previously every test built an `Ac*` value in Rust and read it back, so no test could detect a mismatch with the game.
+- **Shared-Memory Regression Tests**: Added layout tests that parse graphics, physics and static pages captured verbatim from a live AC 1.16.4 session through the same zerocopy call the app uses. Previously every test built an `Ac*` value in Rust and read it back, so no test could detect a mismatch with the game.
+
+### ⚠️ Changed Behaviour
+- **Cold Tyre Pressure Targets Will Shift**: The pressure calculator scales its recommendation by `surface_grip`, which was previously stuck at `0.0` and clamped to a floor of `0.80` — so every recommendation carried the same fixed compensation. Now that real grip is read, a well-rubbered track (≈0.94) produces roughly a third of the previous adjustment. Recommendations will differ from v0.3.0 on the same car and track; this is the fix working, not a regression.
+- **Fuel Strategy Becomes Active**: `fuel_x_lap` was a constant `0.0`, and both the fuel-remaining estimate and the race-fuel target are gated on it being positive, so they never ran. They now do. Note that this field sits in the part of the graphics page not yet confirmed against a live capture — see the note on the tail fields in `core/src/ac_structs.rs`.
 
 ## [v0.3.0] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🛡️ Bug Fixes & Stability
+- **Shared-Memory Graphics Layout**: `AcGraphics` was using Assetto Corsa Competizione's `SPageFileGraphic` layout, which carries `activeCars`, `carCoordinates[60][3]`, `carID[60]`, `playerCarID` and `penalty` — 964 bytes that plain AC never writes. Every field from `car_coordinates` onward was therefore read from the wrong offset, past the end of the 360-byte page AC actually publishes. Track position was plotted from the car's altitude, and `surface_grip`, `fuel_x_lap`, `wind_speed`, `tc`, `abs`, `engine_map`, `flag` and the driver-stint timers all read a constant zero. Reported in [#2](https://github.com/Rgosh/ac-pro-engineer/issues/2).
+- **Shared-Memory Regression Tests**: Added layout tests that parse a page captured verbatim from a live AC 1.16.4 session through the same zerocopy call the app uses. Previously every test built an `Ac*` value in Rust and read it back, so no test could detect a mismatch with the game.
+
 ## [v0.3.0] - 2026-08-02
 
 ### 🚀 New Features & Enhancements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,6 +1857,7 @@ dependencies = [
  "ac_core",
  "ac_tui",
  "tokio",
+ "zerocopy",
 ]
 
 [[package]]

--- a/core/src/ac_structs.rs
+++ b/core/src/ac_structs.rs
@@ -131,9 +131,15 @@ impl From<[u16; 33]> for StringU16_33 {
     }
 }
 
-/// Index into [`AcGraphics::car_coordinates`].
+/// Index of the world X axis in [`AcGraphics::car_coordinates`].
 pub const COORD_X: usize = 0;
+/// Index of the world Y axis — altitude — in [`AcGraphics::car_coordinates`].
+///
+/// A track map wants the ground plane, so it plots [`COORD_X`] against
+/// [`COORD_Z`] and leaves this one alone. Reading altitude as a ground
+/// coordinate is precisely what the old ACC layout did.
 pub const COORD_Y: usize = 1;
+/// Index of the world Z axis in [`AcGraphics::car_coordinates`].
 pub const COORD_Z: usize = 2;
 
 #[repr(C)]

--- a/core/src/ac_structs.rs
+++ b/core/src/ac_structs.rs
@@ -208,6 +208,22 @@ pub struct AcGraphics {
     pub wind_speed: f32,
     pub wind_direction: f32,
     pub is_setup_menu_visible: i32,
+
+    // ── Unverified below this line. ──
+    //
+    // The capture these offsets were read from is zero from 300 to the end of
+    // the page, so it pins nothing here. It does prove AC writes *past* 296 —
+    // a fresh mapping is zero-filled and offset 296 read -1 — which is why
+    // `is_setup_menu_visible` above is trusted and these are not. The order
+    // below is still ACC's, i.e. the same assumption that put
+    // `car_coordinates` in the wrong place to begin with.
+    //
+    // `fuel_x_lap` is the one to be careful with: `engineer.rs` gates fuel
+    // strategy on `fuel_x_lap > 0.0`, so a wrong offset here trades a
+    // permanently dead feature for one that runs on a wrong number, which is
+    // the worse failure. Settling it needs a capture from lap 2 or later —
+    // AC leaves fuelXLap at 0.0 until it has a completed lap to measure, so
+    // the lap-1 capture used here could not have distinguished the two cases.
     pub main_display_index: i32,
     pub secondary_display_index: i32,
     pub tc: i32,

--- a/core/src/ac_structs.rs
+++ b/core/src/ac_structs.rs
@@ -4,10 +4,24 @@ use zerocopy::TryFromBytes;
 
 /// Compile-time guarantee that these structs still match the Assetto Corsa
 /// shared-memory ABI. A mismatch is a build error, not a test failure.
+///
+/// These are the sizes of AC's `SPageFilePhysics` / `SPageFileGraphic` /
+/// `SPageFileStatic`, verified against a live `acpmf_*` mapping from AC 1.16.4
+/// (shared-memory version 1.7). Note that ACC's graphics page is a different,
+/// much larger struct — see the comment on [`AcGraphics`].
 const _: () = {
-    assert!(size_of::<AcGraphics>() == 1320);
-    assert!(size_of::<AcPhysics>() == 596);
-    assert!(size_of::<AcStatic>() == 688);
+    assert!(
+        size_of::<AcGraphics>() == 360,
+        "AcGraphics no longer matches AC's SPageFileGraphic"
+    );
+    assert!(
+        size_of::<AcPhysics>() == 596,
+        "AcPhysics no longer matches AC's SPageFilePhysics"
+    );
+    assert!(
+        size_of::<AcStatic>() == 688,
+        "AcStatic no longer matches AC's SPageFileStatic"
+    );
 };
 
 #[repr(C)]
@@ -117,35 +131,10 @@ impl From<[u16; 33]> for StringU16_33 {
     }
 }
 
-#[repr(C)]
-#[derive(Debug, Clone, Copy, TryFromBytes)]
-pub struct CarCoordinates([[f32; 3]; 60]);
-
-impl Default for CarCoordinates {
-    fn default() -> Self {
-        Self([[0f32; 3]; 60])
-    }
-}
-
-impl CarCoordinates {
-    pub fn get(&self, first: usize, second: usize) -> f32 {
-        self.0[first][second]
-    }
-
-    pub fn set(&mut self, first: usize, second: usize, val: f32) {
-        self.0[first][second] = val;
-    }
-}
-
-#[repr(C)]
-#[derive(Debug, Clone, Copy, TryFromBytes)]
-pub struct CarId([i32; 60]);
-
-impl Default for CarId {
-    fn default() -> Self {
-        Self([0i32; 60])
-    }
-}
+/// Index into [`AcGraphics::car_coordinates`].
+pub const COORD_X: usize = 0;
+pub const COORD_Y: usize = 1;
+pub const COORD_Z: usize = 2;
 
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, TryFromBytes)]
@@ -171,13 +160,18 @@ pub struct AcGraphics {
     pub tyre_compound: StringU16_33,
     pub replay_time_multiplier: f32,
     pub normalized_car_position: f32,
-    pub active_cars: i32,
-    pub car_coordinates: CarCoordinates,
-    pub car_id: CarId,
-    pub player_car_id: i32,
+    /// World position of the *player's* car, `[x, y, z]`, in metres.
+    ///
+    /// AC publishes only the player's car here. ACC is the title with
+    /// `activeCars` + `carCoordinates[60][3]` + `carID[60]` + `playerCarID` in
+    /// this position; those fields do not exist in AC's page, and assuming they
+    /// did shifted every subsequent field 964 bytes past where AC writes it.
+    pub car_coordinates: [f32; 3],
     pub penalty_time: f32,
     pub flag: i32,
-    pub penalty: i32,
+    // No `penalty` field here: that is ACC's `AC_PENALTY_TYPE penalty`. In AC,
+    // `idealLineOn` follows `flag` directly — confirmed by `surfaceGrip`
+    // landing on offset 280 in a live mapping, which it only does without it.
     pub ideal_line_on: i32,
     pub is_in_pit_lane: i32,
     pub surface_grip: f32,

--- a/core/src/ac_structs.rs
+++ b/core/src/ac_structs.rs
@@ -24,6 +24,29 @@ const _: () = {
     );
 };
 
+/// The graphics-page offsets that were read off a live mapping, pinned
+/// individually.
+///
+/// The size assertion above only catches a change that alters the total; it
+/// says nothing about a field inserted and another removed, which is exactly
+/// the shape of the ACC mix-up. These are the offsets a capture actually
+/// confirmed, so a reordering above any of them is a build error instead of a
+/// silent misread. Everything past 296 is deliberately absent — see the note
+/// on the tail fields of [`AcGraphics`].
+const _: () = {
+    use std::mem::offset_of;
+
+    assert!(offset_of!(AcGraphics, current_time) == 12);
+    assert!(offset_of!(AcGraphics, i_current_time) == 140);
+    assert!(offset_of!(AcGraphics, distance_traveled) == 156);
+    assert!(offset_of!(AcGraphics, tyre_compound) == 176);
+    assert!(offset_of!(AcGraphics, normalized_car_position) == 248);
+    assert!(offset_of!(AcGraphics, car_coordinates) == 252);
+    assert!(offset_of!(AcGraphics, surface_grip) == 280);
+    assert!(offset_of!(AcGraphics, wind_speed) == 288);
+    assert!(offset_of!(AcGraphics, is_setup_menu_visible) == 296);
+};
+
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, TryFromBytes)]
 pub struct AcPhysics {

--- a/core/src/analyzer.rs
+++ b/core/src/analyzer.rs
@@ -1,4 +1,4 @@
-use crate::ac_structs::{AcGraphics, AcPhysics};
+use crate::ac_structs::{AcGraphics, AcPhysics, COORD_X, COORD_Z};
 use crate::config::Language;
 use crate::records::TrackRecord;
 use serde::{Deserialize, Serialize};
@@ -635,8 +635,8 @@ impl TelemetryAnalyzer {
                     }
                 };
 
-                let x = g.car_coordinates[crate::ac_structs::COORD_X];
-                let z = g.car_coordinates[crate::ac_structs::COORD_Z];
+                let x = g.car_coordinates[COORD_X];
+                let z = g.car_coordinates[COORD_Z];
 
                 if x.abs() > 0.1 || z.abs() > 0.1 {
                     if x < min_x {

--- a/core/src/analyzer.rs
+++ b/core/src/analyzer.rs
@@ -635,8 +635,8 @@ impl TelemetryAnalyzer {
                     }
                 };
 
-                let x = g.car_coordinates.get(0, 0);
-                let z = g.car_coordinates.get(0, 2);
+                let x = g.car_coordinates[crate::ac_structs::COORD_X];
+                let z = g.car_coordinates[crate::ac_structs::COORD_Z];
 
                 if x.abs() > 0.1 || z.abs() > 0.1 {
                     if x < min_x {

--- a/tests_suite/Cargo.toml
+++ b/tests_suite/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 ac_core = { path = "../core" }
 ac_tui = { path = "../tui" }
 tokio = { version = "1", features = ["full", "test-util"] }
+# Parses captured shared-memory pages through the same call the app uses.
+zerocopy = { workspace = true }

--- a/tests_suite/src/fixtures.rs
+++ b/tests_suite/src/fixtures.rs
@@ -60,7 +60,7 @@ impl TelemetrySessionFixture {
                     ..Default::default()
                 };
 
-                let mut gfx = AcGraphics {
+                let gfx = AcGraphics {
                     status: 1,
                     completed_laps: lap,
                     normalized_car_position: progress,
@@ -77,12 +77,13 @@ impl TelemetrySessionFixture {
                     },
                     session_time_left: (1800.0 - total_time) * 1000.0,
                     fuel_x_lap: 2.1,
+                    car_coordinates: [
+                        400.0 * (progress * std::f32::consts::TAU).cos(),
+                        0.0,
+                        250.0 * (progress * std::f32::consts::TAU).sin(),
+                    ],
                     ..Default::default()
                 };
-                gfx.car_coordinates
-                    .set(0, 0, 400.0 * (progress * std::f32::consts::TAU).cos());
-                gfx.car_coordinates
-                    .set(0, 2, 250.0 * (progress * std::f32::consts::TAU).sin());
 
                 let session = SessionInfo {
                     car_name: "ks_ferrari_488_gt3".to_string(),

--- a/tests_suite/src/lib.rs
+++ b/tests_suite/src/lib.rs
@@ -12,3 +12,6 @@ pub mod overlay_tests;
 
 #[cfg(test)]
 pub mod fixtures;
+
+#[cfg(test)]
+pub mod shm_layout_tests;

--- a/tests_suite/src/shm_layout_tests.rs
+++ b/tests_suite/src/shm_layout_tests.rs
@@ -87,9 +87,15 @@ fn graphics_scalars_decode_to_live_session_values() {
 }
 
 /// `normalized_car_position` (0..1 around the lap) and `distance_traveled`
-/// (metres) are 92 bytes apart and independently written. Dividing one by the
-/// other has to land near a real track length — Imola is 4.9 km — which it
-/// cannot do if either field is misaligned.
+/// (metres) are 92 bytes apart and independently written, so dividing one by
+/// the other has to land in circuit territory — which it cannot do if either
+/// field is misaligned.
+///
+/// The quotient is an over-estimate, not the track length: `distanceTraveled`
+/// accumulates from the grid box while `normalizedCarPosition` is measured
+/// from the start/finish line, so the head start inflates it. This capture
+/// gives 822 m / 0.1548 = 5312 m at Imola, which is 4.9 km. Hence the wide
+/// band below — it is checking the order of magnitude, not the circuit.
 #[test]
 fn lap_fraction_and_distance_imply_a_real_track_length() {
     let g = parse();

--- a/tests_suite/src/shm_layout_tests.rs
+++ b/tests_suite/src/shm_layout_tests.rs
@@ -15,6 +15,20 @@
 //! ACC's layout (`activeCars` + `carCoordinates[60][3]` + `carID[60]` +
 //! `playerCarID` + `penalty`), which is 964 bytes AC never writes, so every
 //! field from `car_coordinates` onward read from the wrong offset.
+//!
+//! # What this does not cover
+//!
+//! Two gaps, both wanting a live session to close rather than more code:
+//!
+//! - **Offsets past 296.** The capture is zero from 300 to the end of the
+//!   page, so the last fifteen fields are asserted by nothing. Reading these
+//!   tests as covering the whole page would be a mistake — see the note on the
+//!   tail fields of `AcGraphics`.
+//! - **`AcPhysics` and `AcStatic`.** Both were checked by hand against the
+//!   same session, but neither has a fixture here, so the round-trip blind
+//!   spot described above still applies to them in full. Capturing
+//!   `acpmf_physics` (596 bytes) and `acpmf_static` (688) alongside a
+//!   lap-2 graphics page would close both gaps in one sitting.
 
 use ac_core::ac_structs::{AcGraphics, COORD_X, COORD_Y, COORD_Z};
 use zerocopy::TryFromBytes;
@@ -158,6 +172,12 @@ fn car_coordinates_are_the_players_world_position() {
 /// off the end of the page, where they read a constant 0.0. `surface_grip`
 /// feeds the cold-pressure calculator and `wind_speed` the strategy tab, so a
 /// silent zero is worse than a crash.
+///
+/// `is_setup_menu_visible` is the last field this capture can speak for. It
+/// reads -1, and a fresh mapping is zero-filled, so AC demonstrably writes at
+/// least this far — which matters, because the published Kunos struct stops at
+/// `wind_direction` and would have the page end at 296. Everything after it is
+/// zero here and proves nothing either way.
 #[test]
 fn fields_after_the_coordinates_are_not_silently_zero() {
     let g = parse();

--- a/tests_suite/src/shm_layout_tests.rs
+++ b/tests_suite/src/shm_layout_tests.rs
@@ -1,0 +1,193 @@
+//! Layout tests for the Assetto Corsa shared-memory structs.
+//!
+//! Every other test in this workspace builds an `Ac*` value in Rust and reads
+//! it back, so it round-trips through whatever layout the struct happens to
+//! declare and cannot detect a mismatch with the game. `simulator.rs` has the
+//! same blind spot: it *writes* the mapping using `size_of::<AcGraphics>()`.
+//!
+//! These tests instead parse bytes captured verbatim from a live
+//! `/dev/shm/acpmf_graphics` (Assetto Corsa 1.16.4, shared-memory version 1.7,
+//! Imola, abarth500) through the exact call the app uses — zerocopy's
+//! `try_read_from_bytes`. If a field moves, the decoded values stop making
+//! sense and these fail.
+//!
+//! This is what caught the bug they exist to prevent: the graphics struct had
+//! ACC's layout (`activeCars` + `carCoordinates[60][3]` + `carID[60]` +
+//! `playerCarID` + `penalty`), which is 964 bytes AC never writes, so every
+//! field from `car_coordinates` onward read from the wrong offset.
+
+use ac_core::ac_structs::{AcGraphics, COORD_X, COORD_Y, COORD_Z};
+use zerocopy::TryFromBytes;
+
+/// First 360 bytes of `/dev/shm/acpmf_graphics`, mid-lap at Imola.
+const GRAPHICS_PAGE_HEX: &str = concat!(
+    "e9b70100020000000200000031003a00340033003a0033003900380000000000",
+    "000000000000000000002d003a002d002d003a002d002d002d00000000000000",
+    "00000000000000002d003a002d002d003a002d002d002d000000000000000000",
+    "0000000000002000000000000000000000000000000000000000000000000000",
+    "000000000000000007000000e6930100000000000000000013f1c9c72b8c4d44",
+    "00000000000000000000000002000000530065006d00690073006c0069006300",
+    "6b0073002000280053004d002900000000000000000000000000000000000000",
+    "00000000000000000000000000000000000000000000803fa17c1e3eefa501c4",
+    "d9a6a4c26389a1c300000000000000000000000000000000be00713f00000000",
+    "0000204100000000ffffffff0000000000000000000000000000000000000000",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "0000000000000000",
+);
+
+fn decode_hex(hex: &str) -> Vec<u8> {
+    assert!(hex.len().is_multiple_of(2), "hex must be byte-aligned");
+    (0..hex.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).expect("valid hex"))
+        .collect()
+}
+
+fn graphics_page() -> Vec<u8> {
+    let bytes = decode_hex(GRAPHICS_PAGE_HEX);
+    assert_eq!(
+        bytes.len(),
+        size_of::<AcGraphics>(),
+        "captured page is {} bytes but AcGraphics is {} — the struct no longer \
+         matches the size AC actually publishes",
+        bytes.len(),
+        size_of::<AcGraphics>()
+    );
+    bytes
+}
+
+/// AC pads its fixed-width `wchar_t` fields with NULs.
+fn utf16_to_string(units: &[u16]) -> String {
+    let end = units.iter().position(|&u| u == 0).unwrap_or(units.len());
+    String::from_utf16_lossy(&units[..end])
+}
+
+fn parse() -> AcGraphics {
+    // The same call `SharedMemory::get` makes on the real mapping.
+    AcGraphics::try_read_from_bytes(&graphics_page()).expect("real AC page must parse")
+}
+
+#[test]
+fn graphics_page_size_matches_the_struct() {
+    // Deliberately separate from the parse tests: if AC's page and the struct
+    // disagree in size, that alone is the bug, whatever the fields decode to.
+    let _ = graphics_page();
+}
+
+#[test]
+fn graphics_scalars_decode_to_live_session_values() {
+    let g = parse();
+    assert_eq!(g.packet_id, 112617);
+    assert_eq!(g.status, 2, "AC_LIVE");
+    assert_eq!(g.session, 2, "AC_RACE");
+    assert_eq!(g.position, 7);
+    assert_eq!(g.number_of_laps, 2);
+    assert_eq!(g.completed_laps, 0);
+    assert_eq!(g.replay_time_multiplier, 1.0);
+}
+
+/// `normalized_car_position` (0..1 around the lap) and `distance_traveled`
+/// (metres) are 92 bytes apart and independently written. Dividing one by the
+/// other has to land near a real track length — Imola is 4.9 km — which it
+/// cannot do if either field is misaligned.
+#[test]
+fn lap_fraction_and_distance_imply_a_real_track_length() {
+    let g = parse();
+    assert!(
+        (0.0..=1.0).contains(&g.normalized_car_position),
+        "normalized_car_position = {} is not a lap fraction",
+        g.normalized_car_position
+    );
+
+    let implied_track_length = g.distance_traveled / g.normalized_car_position;
+    assert!(
+        (3_000.0..=8_000.0).contains(&implied_track_length),
+        "implied track length {implied_track_length:.0} m is not a circuit \
+         ({} m travelled at lap fraction {})",
+        g.distance_traveled,
+        g.normalized_car_position
+    );
+}
+
+/// `current_time` is a formatted string and `i_current_time` the same value in
+/// milliseconds. They are 108 bytes apart, so agreeing is strong evidence the
+/// whole front half is aligned rather than coincidentally plausible.
+#[test]
+fn formatted_and_numeric_lap_time_agree() {
+    let g = parse();
+    assert_eq!(g.i_current_time, 103_398);
+    assert_eq!(utf16_to_string(&g.current_time), "1:43:398");
+}
+
+#[test]
+fn tyre_compound_decodes_as_utf16() {
+    assert_eq!(parse().tyre_compound.to_string(), "Semislicks (SM)");
+}
+
+/// The regression itself. Under the old ACC layout `car_coordinates` started 4
+/// bytes late, so x read the altitude, y read z, and z read a neighbouring
+/// car's x — which in a single-car session was 0.0.
+#[test]
+fn car_coordinates_are_the_players_world_position() {
+    let c = parse().car_coordinates;
+
+    // Imola is roughly 1km across and sits near y=0; a misread lands orders of
+    // magnitude away or exactly zero.
+    assert!(
+        (-1000.0..=1000.0).contains(&c[COORD_X]) && c[COORD_X].abs() > 1.0,
+        "x = {} is not a plausible world coordinate",
+        c[COORD_X]
+    );
+    assert!(
+        (-1000.0..=1000.0).contains(&c[COORD_Z]) && c[COORD_Z].abs() > 1.0,
+        "z = {} is not a plausible world coordinate",
+        c[COORD_Z]
+    );
+    assert!((c[COORD_X] - -518.59).abs() < 0.1, "x = {}", c[COORD_X]);
+    assert!((c[COORD_Y] - -82.33).abs() < 0.1, "y = {}", c[COORD_Y]);
+    assert!((c[COORD_Z] - -323.07).abs() < 0.1, "z = {}", c[COORD_Z]);
+}
+
+/// Fields after `car_coordinates` are the ones the 964-byte overshoot pushed
+/// off the end of the page, where they read a constant 0.0. `surface_grip`
+/// feeds the cold-pressure calculator and `wind_speed` the strategy tab, so a
+/// silent zero is worse than a crash.
+#[test]
+fn fields_after_the_coordinates_are_not_silently_zero() {
+    let g = parse();
+
+    assert!(
+        (g.surface_grip - 0.9414).abs() < 0.001,
+        "surface_grip = {} (0.0 means it is reading past the page again)",
+        g.surface_grip
+    );
+    assert!(
+        (g.wind_speed - 10.0).abs() < 0.001,
+        "wind_speed = {}",
+        g.wind_speed
+    );
+    assert_eq!(g.wind_direction, 0.0);
+    assert_eq!(g.is_setup_menu_visible, -1);
+
+    // Quiet in this capture, but they must still land inside the page.
+    assert_eq!(g.penalty_time, 0.0);
+    assert_eq!(g.flag, 0, "AC_NO_FLAG");
+    assert_eq!(g.is_in_pit_lane, 0);
+    assert_eq!(g.mandatory_pit_done, 0);
+    assert_eq!(g.rain_tyres, 0);
+}
+
+/// A page one field longer or shorter must be refused rather than parsed from
+/// whatever happens to be adjacent.
+#[test]
+fn a_wrong_sized_page_does_not_parse() {
+    let good = graphics_page();
+
+    let mut short = good.clone();
+    short.pop();
+    assert!(AcGraphics::try_read_from_bytes(&short).is_err());
+
+    let mut long = good;
+    long.extend_from_slice(&[0u8; 4]);
+    assert!(AcGraphics::try_read_from_bytes(&long).is_err());
+}

--- a/tests_suite/src/shm_layout_tests.rs
+++ b/tests_suite/src/shm_layout_tests.rs
@@ -16,21 +16,19 @@
 //! `playerCarID` + `penalty`), which is 964 bytes AC never writes, so every
 //! field from `car_coordinates` onward read from the wrong offset.
 //!
+//! All three pages come from one AC run: the graphics page mid-lap, the
+//! physics and static pages after returning to the menu, which is why the
+//! latter two show a car sitting cold and stationary in the pits.
+//!
 //! # What this does not cover
 //!
-//! Two gaps, both wanting a live session to close rather than more code:
-//!
-//! - **Offsets past 296.** The capture is zero from 300 to the end of the
-//!   page, so the last fifteen fields are asserted by nothing. Reading these
-//!   tests as covering the whole page would be a mistake — see the note on the
-//!   tail fields of `AcGraphics`.
-//! - **`AcPhysics` and `AcStatic`.** Both were checked by hand against the
-//!   same session, but neither has a fixture here, so the round-trip blind
-//!   spot described above still applies to them in full. Capturing
-//!   `acpmf_physics` (596 bytes) and `acpmf_static` (688) alongside a
-//!   lap-2 graphics page would close both gaps in one sitting.
+//! **Graphics offsets past 296.** The graphics capture is zero from 300 to the
+//! end of the page, so the last fifteen fields are asserted by nothing.
+//! Reading these tests as covering that page end to end would be a mistake —
+//! see the note on the tail fields of `AcGraphics`. Settling it needs a
+//! capture taken from lap 2 or later, with TC/ABS set and the headlights on.
 
-use ac_core::ac_structs::{AcGraphics, COORD_X, COORD_Y, COORD_Z};
+use ac_core::ac_structs::{AcGraphics, AcPhysics, AcStatic, COORD_X, COORD_Y, COORD_Z};
 use zerocopy::TryFromBytes;
 
 /// First 360 bytes of `/dev/shm/acpmf_graphics`, mid-lap at Imola.
@@ -49,6 +47,58 @@ const GRAPHICS_PAGE_HEX: &str = concat!(
     "0000000000000000",
 );
 
+/// All 596 bytes of `/dev/shm/acpmf_physics`, car stopped in the pits.
+const PHYSICS_PAGE_HEX: &str = concat!(
+    "d4e0000000000000000000007322ec410100000052030000000000007691e439",
+    "0000000000000000000000000000000000000000000000004f00b13c48fba63c",
+    "f30f0b3d9156033d3fef5145947f5045694211456dba11456387e1418a99e041",
+    "3465c841915dc7410000000000000000f8edcbb9ea4ac7b90000c8420000c842",
+    "0000c8420000c842e14f863fd35f913ff63c8e3fe23c983f2b8ed941a1bfd341",
+    "8478a041cc089a414554bdbc3270ac3cf88711bdd120073d80959f3da8e89e3d",
+    "046bbf3d3aecbf3d00000000cdcccc3d6d13bd3e0134d0bbdad59a3a0011083f",
+    "936150418467e7409c1dff4000000000936150410000000000000000ae47e13d",
+    "00000000000000000000000000f61b3e00d8473e5f4fce0300000000a01a9f3f",
+    "0000404100002041000000000000000000000000175693370000000000000000",
+    "0000000000000000000000000000000000000000000000000000000000004041",
+    "00004041000040410000404100000000963106425e800442d2d3af41305cac41",
+    "92d004429f9600422f51b0417782a641edff0742d40701428a03b6414b2aa541",
+    "00000000317428c41954a3c23a8099c2e2c728c47253a3c21e839ac25a3f28c4",
+    "5958a3c22cc79dc2d19228c45757a3c290c99ec2c3b0843b76ff7f3fb9a4b5b7",
+    "949ed03ab1ff7f3f72682bbb25d3b13bebfe7f3f1a2ff7ba2b5d0a3b72ff7f3f",
+    "7f4567bbf245b93ebab5c2baaaa66ebfe456b83eef7745bbb0d46ebfa113ba3e",
+    "ec6574bb3c7e6ebfa180b73eb4bf84bba9fd6ebf9a99593f0000000000000000",
+    "0000000000000000000000006419000000000000",
+);
+
+/// All 688 bytes of `/dev/shm/acpmf_static`, same run.
+///
+/// The player-name fields are AC's out-of-the-box `Player`, so there is
+/// nothing personal in here to leak into the repository.
+const STATIC_PAGE_HEX: &str = concat!(
+    "31002e0037000000000000000000000000000000000000000000000000003100",
+    "2e00310036002e00340000000000000000000000000000000000000001000000",
+    "0800000061006200610072007400680035003000300000000000000000000000",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "00000000000069006d006f006c00610000000000000000000000000000000000",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "000000000000000050006c006100790065007200000000000000000000000000",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "0000000000000000000050006c00610079006500720000000000000000000000",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "00000000000000000000000050006c0061007900650072000000000000000000",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "00000000000000000000000000000000030000000000bc42ac98e34764190000",
+    "00000c4200000000000000007b14ae3d7b14ae3dd6c59d3ed6c59d3ed6c59d3e",
+    "d6c59d3ed7a3b03f0000000000000000010000000000803f0000803f0000803f",
+    "0000000000000000010000000000000000000000000000000000000000000000",
+    "0000000000000000dc0098450000000000000000000000000000000000000000",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "0000000000000000000000000000000000000000000000000000000030005f00",
+    "770068006900740065005f00730063006f007200700069006f006e0000000000",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "00000000000000000000000000000000",
+);
+
 fn decode_hex(hex: &str) -> Vec<u8> {
     assert!(hex.len().is_multiple_of(2), "hex must be byte-aligned");
     (0..hex.len())
@@ -57,17 +107,31 @@ fn decode_hex(hex: &str) -> Vec<u8> {
         .collect()
 }
 
-fn graphics_page() -> Vec<u8> {
-    let bytes = decode_hex(GRAPHICS_PAGE_HEX);
+/// Decodes a captured page and holds it against the struct that claims to
+/// describe it, before any field is read.
+fn page<T>(hex: &str, what: &str) -> Vec<u8> {
+    let bytes = decode_hex(hex);
     assert_eq!(
         bytes.len(),
-        size_of::<AcGraphics>(),
-        "captured page is {} bytes but AcGraphics is {} — the struct no longer \
+        size_of::<T>(),
+        "captured {what} page is {} bytes but the struct is {} — it no longer \
          matches the size AC actually publishes",
         bytes.len(),
-        size_of::<AcGraphics>()
+        size_of::<T>()
     );
     bytes
+}
+
+fn graphics_page() -> Vec<u8> {
+    page::<AcGraphics>(GRAPHICS_PAGE_HEX, "graphics")
+}
+
+fn physics_page() -> Vec<u8> {
+    page::<AcPhysics>(PHYSICS_PAGE_HEX, "physics")
+}
+
+fn static_page() -> Vec<u8> {
+    page::<AcStatic>(STATIC_PAGE_HEX, "static")
 }
 
 /// AC pads its fixed-width `wchar_t` fields with NULs.
@@ -76,9 +140,18 @@ fn utf16_to_string(units: &[u16]) -> String {
     String::from_utf16_lossy(&units[..end])
 }
 
+// All three go through the same call `SharedMemory::get` makes on the real
+// mapping — zerocopy's `try_read_from_bytes`.
 fn parse() -> AcGraphics {
-    // The same call `SharedMemory::get` makes on the real mapping.
     AcGraphics::try_read_from_bytes(&graphics_page()).expect("real AC page must parse")
+}
+
+fn parse_physics() -> AcPhysics {
+    AcPhysics::try_read_from_bytes(&physics_page()).expect("real AC page must parse")
+}
+
+fn parse_static() -> AcStatic {
+    AcStatic::try_read_from_bytes(&static_page()).expect("real AC page must parse")
 }
 
 #[test]
@@ -201,6 +274,145 @@ fn fields_after_the_coordinates_are_not_silently_zero() {
     assert_eq!(g.is_in_pit_lane, 0);
     assert_eq!(g.mandatory_pit_done, 0);
     assert_eq!(g.rain_tyres, 0);
+}
+
+#[test]
+fn physics_page_size_matches_the_struct() {
+    let _ = physics_page();
+}
+
+#[test]
+fn static_page_size_matches_the_struct() {
+    let _ = static_page();
+}
+
+/// Captured with the car parked, which is a state every field has to be
+/// consistent with at once: no throttle, no brake, idling, not moving.
+#[test]
+fn physics_decodes_a_car_stationary_in_the_pits() {
+    let p = parse_physics();
+    assert_eq!(p.packet_id, 57556);
+    assert_eq!(p.gas, 0.0);
+    assert_eq!(p.brake, 0.0);
+    assert_eq!(p.gear, 1, "AC counts neutral as gear 1");
+    assert_eq!(p.rpms, 850, "idling");
+    assert!(p.speed_kmh < 0.01, "speed_kmh = {}", p.speed_kmh);
+    assert_eq!(p.tyre_wear, [100.0; 4], "AC counts 100 as unworn");
+}
+
+/// The abarth500 is front-engined, so the front wheels must carry the heavier
+/// share. `wheel_load` is at offset 72 and the total has to come out as a real
+/// car's mass — a misalignment breaks the split, the magnitude, or both.
+#[test]
+fn physics_weight_distribution_is_a_front_engined_car() {
+    let p = parse_physics();
+    let front = p.wheel_load[0] + p.wheel_load[1];
+    let rear = p.wheel_load[2] + p.wheel_load[3];
+
+    assert!(
+        front > rear,
+        "front axle {front:.0} N should outweigh the rear {rear:.0} N"
+    );
+
+    let mass_kg = (front + rear) / 9.81;
+    assert!(
+        (700.0..=1500.0).contains(&mass_kg),
+        "{mass_kg:.0} kg is not a car ({front:.0} N front, {rear:.0} N rear)"
+    );
+}
+
+/// Three independent temperature readings of a car that has been sitting:
+/// ambient at 288, road at 292 and the brakes at 348. They only agree on a
+/// cold garage if all three are aligned.
+#[test]
+fn physics_temperatures_agree_across_the_struct() {
+    let p = parse_physics();
+    assert_eq!(p.air_temp, 12.0);
+    assert_eq!(p.road_temp, 10.0);
+
+    for (i, t) in p.brake_temp.iter().enumerate() {
+        assert!(
+            (t - 12.0).abs() < 1.0,
+            "brake {i} at {t} °C, expected ambient on a car that has not moved"
+        );
+    }
+
+    // tyre_core_temp (152) and the i/m/o triplet (368/384/400) measure the
+    // same four tyres 216 bytes apart, so the warmer pair must be the same.
+    assert!(
+        p.tyre_core_temp[0] > p.tyre_core_temp[2] && p.tyre_temp_m[0] > p.tyre_temp_m[2],
+        "core and surface disagree on which axle is warmer: {:?} vs {:?}",
+        p.tyre_core_temp,
+        p.tyre_temp_m
+    );
+}
+
+#[test]
+fn static_versions_decode_as_utf16() {
+    let s = parse_static();
+    assert_eq!(utf16_to_string(&s.sm_version), "1.7");
+    assert_eq!(utf16_to_string(&s.ac_version), "1.16.4");
+}
+
+/// `track` sits at offset 134 and `track_spline_length` at 520. Naming the
+/// circuit and measuring it are 386 bytes apart, so agreeing rules out an
+/// accidental alignment of the front of the struct.
+#[test]
+fn static_track_name_and_length_agree() {
+    let s = parse_static();
+    assert_eq!(s.track.to_string(), "imola");
+    assert_eq!(s.sector_count, 3);
+    assert!(
+        (s.track_spline_length - 4864.0).abs() < 10.0,
+        "spline length {} m does not match Imola's 4.9 km",
+        s.track_spline_length
+    );
+}
+
+/// Same argument for the car: named at 68, specified from 404 onward, and
+/// skinned at 604 — which is 84 bytes from the end of the page.
+#[test]
+fn static_car_name_and_specs_agree() {
+    let s = parse_static();
+    assert_eq!(s.car_model.to_string(), "abarth500");
+    assert_eq!(s.max_rpm, 6500);
+    assert_eq!(s.max_fuel, 35.0);
+    assert!(
+        (s.tyre_radius[0] - 0.308).abs() < 0.001,
+        "tyre radius {} m",
+        s.tyre_radius[0]
+    );
+    assert!(s.max_turbo_boost > 0.0, "the abarth500 is turbocharged");
+    assert_eq!(s.car_skin.to_string(), "0_white_scorpion");
+}
+
+/// The check no single-page fixture can make. These came from one AC run, so
+/// the pages have to agree with each other — and they are three separate
+/// structs, so a layout error in any one of them shows up here.
+#[test]
+fn the_pages_agree_with_each_other() {
+    let p = parse_physics();
+    let s = parse_static();
+    let g = parse();
+
+    assert!(
+        p.fuel > 0.0 && p.fuel <= s.max_fuel,
+        "{} L on board does not fit the {} L tank",
+        p.fuel,
+        s.max_fuel
+    );
+    assert!(
+        p.rpms <= s.max_rpm,
+        "{} rpm exceeds the {} rpm limit",
+        p.rpms,
+        s.max_rpm
+    );
+    assert!(
+        g.distance_traveled < s.track_spline_length,
+        "{} m travelled on lap 1 of a {} m circuit",
+        g.distance_traveled,
+        s.track_spline_length
+    );
 }
 
 /// A page one field longer or shorter must be refused rather than parsed from

--- a/tui/src/bin/simulator.rs
+++ b/tui/src/bin/simulator.rs
@@ -289,7 +289,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             (*gfx).i_best_time = best_lap_time_ms;
             (*gfx).session_time_left = ((3600.0 - total_elapsed) * 1000.0).max(0.0);
             (*gfx).distance_traveled = dist;
+            (*gfx).normalized_car_position = scenario_phase;
             (*gfx).surface_grip = 0.98;
+
+            // Trace a closed loop so the track map has something to plot. AC
+            // publishes the player's world position here, x/z being the ground
+            // plane and y the altitude; the shape matches the one the TUI draws
+            // for demo mode so the two look alike side by side.
+            let angle = scenario_phase * std::f32::consts::TAU;
+            (*gfx).car_coordinates = [
+                400.0 * angle.cos() + 50.0 * (2.0 * angle).cos(),
+                0.0,
+                250.0 * angle.sin() + 30.0 * (3.0 * angle).sin(),
+            ];
             (*gfx).fuel_x_lap = if fuel_per_lap > 0.0 {
                 fuel_per_lap
             } else {

--- a/tui/src/ui/tabs/telemetry.rs
+++ b/tui/src/ui/tabs/telemetry.rs
@@ -240,8 +240,8 @@ fn render_track_map(f: &mut Frame<'_>, area: Rect, app: &AppState) {
     let y_bounds = [min_y - margin_y, max_y + margin_y];
 
     let car_pos = if let Some(gfx) = app.ac_graphics() {
-        let cx = gfx.car_coordinates.get(0, 0) as f64;
-        let cy = gfx.car_coordinates.get(0, 2) as f64;
+        let cx = gfx.car_coordinates[ac_core::ac_structs::COORD_X] as f64;
+        let cy = gfx.car_coordinates[ac_core::ac_structs::COORD_Z] as f64;
         if cx.is_finite() && cy.is_finite() && (cx != 0.0 || cy != 0.0) {
             Some((cx, cy))
         } else if app.is_demo_mode {

--- a/tui/src/ui/tabs/telemetry.rs
+++ b/tui/src/ui/tabs/telemetry.rs
@@ -1,5 +1,6 @@
 use crate::AppState;
 use crate::ui::localization::tr;
+use ac_core::ac_structs::{COORD_X, COORD_Z};
 use ratatui::widgets::canvas::{Canvas, Circle, Line as CanvasLine, Points};
 use ratatui::{prelude::*, widgets::*};
 
@@ -240,8 +241,8 @@ fn render_track_map(f: &mut Frame<'_>, area: Rect, app: &AppState) {
     let y_bounds = [min_y - margin_y, max_y + margin_y];
 
     let car_pos = if let Some(gfx) = app.ac_graphics() {
-        let cx = gfx.car_coordinates[ac_core::ac_structs::COORD_X] as f64;
-        let cy = gfx.car_coordinates[ac_core::ac_structs::COORD_Z] as f64;
+        let cx = gfx.car_coordinates[COORD_X] as f64;
+        let cy = gfx.car_coordinates[COORD_Z] as f64;
         if cx.is_finite() && cy.is_finite() && (cx != 0.0 || cy != 0.0) {
             Some((cx, cy))
         } else if app.is_demo_mode {


### PR DESCRIPTION
Fixes [#2](https://github.com/Rgosh/ac-pro-engineer/issues/2). The report describes a 4-byte offset on `car_coordinates`; the actual problem is larger.

## What was wrong

`AcGraphics` was using **Assetto Corsa Competizione's** `SPageFileGraphic`, not AC's. ACC's version carries five fields that plain AC never writes:

```c
int   activeCars;
float carCoordinates[60][3];
int   carID[60];
int   playerCarID;
...
int   penalty;              // AC_PENALTY_TYPE, sits after flag
```

That's **964 bytes** AC does not publish. Every field from `car_coordinates` onward was read from the wrong offset — and since AC's graphics page is only **360 bytes**, most landed past its end, where the mapping is zeroed.

In AC, `carCoordinates` is a `float[3]` holding the **player's** car position, immediately after `normalizedCarPosition`.

## Evidence

Verified against a live `/dev/shm/acpmf_graphics` from **AC 1.16.4** (shared-memory version 1.7), sampling three times 0.7 s apart:

```
252  =  256.16107   CHANGING     ← world X (car moving)
256  =  -84.95914   constant     ← world Y (altitude)
260  = -390.70932   CHANGING     ← world Z (car moving)
280  =    0.94343                ← surfaceGrip
288  =   10.0                    ← windSpeed
360..1320                        ← all zero
```

X and Z drift while Y holds still — the signature of world coordinates, starting at **252**.

Three independent confirmations:

- Reading offset 252 as `active_cars` gives **`1132467545`**, the bit pattern of the float 256.167 — not a car count. The static page reported `numCars = 8`.
- The absence of `penalty` is pinned the same way: `surfaceGrip` only lands on 280 without it.
- Offset 296 reads **-1** on a zero-filled mapping, so AC demonstrably writes past 296. This matters because the published Kunos struct stops at `windDirection` and would end the page at 296.

Across all three pages, nothing beyond the declared struct size is ever non-zero within the 2048-byte mapping — 360 for graphics, 596 for physics, 688 for static.

## Impact beyond the track map

These all read a constant zero, because they were being read past the end of the page. Split by what the capture actually proves:

**Confirmed by the capture** (offset ≤ 296):

| field | offset | consumers | effect |
|---|---|---|---|
| `surface_grip` | 280 | 4 | feeds `track_grip` and the cold-pressure calculator |
| `wind_speed` | 288 | 1 | strategy tab |
| `penalty_time`, `flag`, `is_in_pit_lane`, `mandatory_pit_done` | 264–284 | — | always 0 |

**Not confirmed** (offset ≥ 300 — see *Remaining gap* below):

| field | offset | consumers | effect |
|---|---|---|---|
| `fuel_x_lap` | 324 | 5 | fuel strategy |
| `tc`, `abs`, `engine_map` | 308–320 | — | always 0 |
| light/rain fields, stint timers | 328–356 | — | always 0 |

## API change

`CarCoordinates` and `CarId` are removed. `get(0, 0)` meant "car 0, axis 0" — a distinction AC's page does not have. `car_coordinates` is now a plain `[f32; 3]` indexed with `COORD_X` / `COORD_Y` / `COORD_Z`, matching how `AcPhysics` already declares `velocity`, `acc_g` and `local_velocity`, so call sites state which axis they mean.

## Changed behaviour for users

Two features were reading a constant zero and now read real data. Both will produce different numbers on a familiar car and track, which reads as a regression unless the release notes say otherwise:

- **Cold tyre pressure targets shift.** The calculator scales by `surface_grip`, which was pinned at `0.0` and clamped to a floor of `0.80`, so every recommendation carried the same fixed compensation. At a realistic 0.94 the adjustment drops to roughly a third of what it was.
- **Fuel strategy activates.** Both the fuel-remaining estimate and the race-fuel target are gated on `fuel_x_lap > 0.0`, so neither has ever run.

## Why no test caught this

Every test in the workspace builds an `Ac*` value in Rust and reads it back, so it round-trips through whatever layout the struct declares. `simulator.rs` has the same blind spot — it *writes* the mapping using `size_of::<AcGraphics>()`. Nothing validated against the game.

This PR adds `tests_suite/src/shm_layout_tests.rs`, which parses pages captured verbatim from a live session through the same zerocopy call `SharedMemory::get` makes. All three pages are covered. The assertions lean on agreement between distant fields, which only holds under correct alignment:

- graphics: `i_current_time` (103398 ms) matches the `current_time` string `"1:43:398"` — 108 bytes apart
- static: `track` is `imola` at offset 134 and `track_spline_length` is 4864 m at 520 — 386 bytes apart
- static: `car_model` is `abarth500` at 68, specified from 404 as 6500 rpm, a 35 L tank and 0.308 m tyres
- physics: the front axle outweighs the rear (front-engined car), totalling ~1160 kg
- physics: air, road and brake temperatures agree on a cold garage from offsets 288, 292 and 348
- across pages: fuel on board fits the tank, rpm is under the limiter, lap-1 distance is shorter than the circuit

The bytes are inline hex constants rather than binary fixtures, which also makes them reviewable in the diff. The player-name fields are AC's default `Player`, so no personal data is committed.

`ac_structs.rs` also pins the nine graphics offsets the capture confirmed. The size assertion alone cannot catch a field added in one place and removed in another — which is the shape of this bug — so the offsets are asserted individually.

Both guards were mutation-tested rather than assumed:

- reintroducing ACC's `penalty` after `flag` trips the size assert *and* the `surface_grip` offset
- swapping `surface_grip` with `mandatory_pit_done` keeps the size at 360, so only the offset assert fires
- swapping `max_rpm` with `max_fuel` and `air_temp` with `road_temp` is size-neutral in both other structs, and three of the new fixture tests fail

## Remaining gap

**Graphics offsets 300–359 are inferred, not verified.** The capture is zero from 300 to the end of the page, so the last fifteen fields still carry ACC's ordering — the same assumption that caused this bug. Nothing in the tests distinguishes a correct tail from a wrong one.

`fuel_x_lap` (offset 324) is the one that matters: `engineer.rs` gates fuel strategy on `fuel_x_lap > 0.0`, so a wrong offset there trades a permanently dead feature for one running on a wrong number, which is the worse failure. The lap-1 capture could not have distinguished the two cases — AC leaves `fuelXLap` at 0.0 until it has a completed lap to measure.

Settling it needs one capture from **lap 2 or later, with TC/ABS set and the headlights on**. This is documented at the boundary in `core/src/ac_structs.rs` and in the changelog rather than left implicit.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0 on `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-gnu`
- `cargo fmt --all --check` — clean
- `cargo test --workspace` — **126 passed, 0 failed** (was 109)

## Note for the reviewer

The struct is now correct for **AC**. If ACC support is ever wanted, it needs its own struct rather than a widened shared one — the two pages genuinely differ, and conflating them is what caused this.

`simulator.rs` now publishes `car_coordinates`, so the track map can be exercised without launching the game. Note that binary calls `set_len()` on `/dev/shm/acpmf_graphics` and must not be run while AC is live, or it will truncate the game's own mapping.

Worth a sanity check on track once merged: the track map should trace the circuit instead of pinning to a fixed point, and the Strategy tab should show a real surface-grip figure rather than 0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
