### PR TITLE
Linux desktop launch + overlay plan

### DIFF
--- a/docs/overlay-lua-plan.md
+++ b/docs/overlay-lua-plan.md
@@ -1,0 +1,277 @@
+# In-game overlay via a CSP Lua app
+
+Design for replacing the overlay with a Lua app that draws inside Assetto
+Corsa, while all computation stays in Rust.
+
+## Why the current overlay does not work
+
+- `NativeWindowProvider` is `#[cfg(target_os = "windows")]` only, 422 lines of
+  Win32. On Linux `OverlayManager::new` selects `None` and `render` is a no-op —
+  there is no overlay at all on the platform this project otherwise supports.
+- `OpenXrProvider` is a 24-line stub: `init` returns `Ok`, `render` does
+  nothing. VR mode has never drawn anything.
+- Even on Windows a separate always-on-top window is the wrong shape. It does
+  not survive exclusive fullscreen, does not appear in VR, and is invisible to
+  AC's own screenshot and replay systems.
+
+Drawing inside the game is the only approach that solves all three, and AC has
+exactly one supported way to do that: a Custom Shaders Patch Lua app.
+
+## The idea, and why it is the right one
+
+Rust computes, Lua only draws. The split matters because the two sides have
+very different costs:
+
+- Lua runs **on AC's render thread**. Every millisecond spent there is a
+  millisecond off the frame budget. At 165 Hz the whole frame is 6 ms.
+- LuaJIT allocates and garbage-collects. Anything that parses text, builds
+  tables or formats strings per frame produces garbage that gets collected
+  *during* a frame, which shows up as a stutter rather than as lower average
+  FPS.
+
+So the goal is: **the Lua app performs no computation, no parsing and no
+allocation per frame** — it reads fields out of a struct at a fixed address and
+passes them to ImGui.
+
+## Architecture
+
+```
+  Rust: ac_pro_engineer            shared memory              CSP Lua app
+  ┌──────────────────────┐      ┌────────────────┐      ┌──────────────────┐
+  │ analyzer / engineer  │      │  OverlayFrame  │      │ script.update()  │
+  │        ↓             │─────▶│  (packed C     │─────▶│   read fields    │
+  │ pack once per tick   │write │   struct)      │ read │   draw ImGui     │
+  └──────────────────────┘      └────────────────┘      └──────────────────┘
+       ~60 Hz, 1 memcpy            fixed ~512 B            zero allocation
+```
+
+One writer, one reader, one struct. No serialisation on either side: the bytes
+Rust writes are the bytes Lua reads, interpreted through the same layout.
+
+### Why not the alternatives
+
+| Approach | Per-frame cost in Lua | Verdict |
+|---|---|---|
+| **Shared struct** | pointer deref | chosen |
+| JSON over file | parse ~2 KB, allocate tables | GC stutter every frame |
+| TCP/UDP socket | syscall + parse | CSP Lua networking is restricted; same parsing cost |
+| Lua computes from `ac.getCar()` | full analyzer in Lua | duplicates thousands of lines, on the render thread |
+
+## The data contract
+
+### Layout rules (verified against the CSP SDK)
+
+CSP's `ac.StructItem` **reorders structure fields by default** for optimal
+packing. The SDK says so explicitly:
+
+> By default, CSP will reorder fields in your structures for optimal data
+> packing. […] if you want for your script to exchange data with other
+> programs, explicit order would work much better.
+
+So the Lua side **must** call `ac.StructItem.explicitOrder(4, 4)` — without it
+the field order is decided by CSP's packing algorithm and will not match a
+`#[repr(C)]` Rust struct. This is the single most likely cause of a "reads
+garbage" bug, and it is silent.
+
+Rules for the shared struct:
+
+1. Rust side is `#[repr(C)]`, Lua side declares `explicitOrder`.
+2. Fixed-size scalars only — `i32`, `f32`, fixed `[u8; N]` for text. No
+   pointers, no Rust `String`, no `Vec`.
+3. Fields ordered largest-alignment first, so no padding differences can arise.
+4. A `version: u32` first field. Lua refuses to draw if it does not recognise
+   it, rather than misinterpreting a struct from a different release.
+
+### Sketch
+
+```rust
+#[repr(C)]
+pub struct OverlayFrame {
+    version: u32,          // ACPE_OVERLAY_VERSION
+    sequence: u32,         // torn-read detection, see below
+    speed_kmh: f32,
+    rpm: i32,
+    gear: i32,
+    fuel_laps_remaining: f32,
+    delta_ms: i32,
+    tyre_pressure: [f32; 4],
+    tyre_temp: [f32; 4],
+    brake_temp: [f32; 4],
+    tyre_wear: [f32; 4],
+    // ...
+    message_count: u32,
+    messages: [[u8; 64]; 4],   // engineer advice, UTF-8, NUL-padded
+}
+```
+
+Roughly 512 bytes. At 60 Hz that is **30 KB/s** of writes and a single
+`memcpy` per tick — against the ~9 MB/s the app already reads out of AC's own
+shared memory. Immaterial.
+
+### Torn reads
+
+Same problem the app just fixed on the reading side, now as the writer: Lua
+can read while Rust writes. Use the sequence-lock the codebase already
+understands:
+
+- Rust: `sequence += 1` (now odd) → write fields → `sequence += 1` (now even).
+- Lua: read `sequence`, read fields, read `sequence` again; if it changed or is
+  odd, keep the previous frame's values.
+
+Skipping one frame at 60 Hz is invisible. A spliced frame is not — it produces
+a flickering wrong number, which is exactly the class of bug the `packet_id`
+work in v0.3.1 removed from the input side.
+
+## Platform specifics
+
+### Windows
+
+The Rust app creates the mapping directly with `CreateFileMappingW`. This is
+the same API `shm-bridge` already wraps in `FileMapping::new`, so the code
+exists.
+
+### Linux — the part that needs the bridge
+
+The Rust app is a **native Linux process**. AC and CSP run under **Proton**. A
+Linux process cannot create a Win32 named object that Wine will resolve.
+
+The project already solved this in the other direction, and the same mechanism
+inverts cleanly. `shm-bridge.exe` runs under Wine, opens a file under
+`/dev/shm/`, and calls `CreateFileMappingW(name, file, size)` — a **file-backed**
+named mapping. Both sides then see the same bytes:
+
+- Wine side (AC, CSP Lua): a `Local\<name>` named mapping
+- Linux side (our app): an ordinary file at `/dev/shm/<name>`, mmap-able
+
+For the overlay, add one more name to `ACC_FILES` in the bridge. Rust opens
+`/dev/shm/<name>` read-write and mmaps it; Lua opens the Windows name. Nothing
+new has to be invented and nothing new has to be installed — the bridge is
+already shipped and already running whenever the app reads telemetry on Linux.
+
+### The name
+
+`ac.readMemoryMappedFile` refuses names for scripts without IO permission
+**unless the name starts with `AcTools.CSP.Limited.`**:
+
+```lua
+if not __allowIO__ and not string.startsWith(filename, 'AcTools.CSP.Limited.') then
+  error('Script of this type can't access shared memory files', 2)
+end
+```
+
+Using that prefix works whether or not the app is granted IO, so it removes an
+entire category of "works on my machine" failure. Proposed:
+
+```
+AcTools.CSP.Limited.ACPE.v1
+```
+
+## The Lua app
+
+Layout under the AC install:
+
+```
+assettocorsa/apps/lua/ac_pro_engineer/
+├── manifest.ini
+└── ac_pro_engineer.lua
+```
+
+Skeleton:
+
+```lua
+local FRAME = ac.StructItem.combine({
+  ac.StructItem.explicitOrder(4, 4),   -- REQUIRED, see layout rules
+  version  = ac.StructItem.uint32(),
+  sequence = ac.StructItem.uint32(),
+  speed    = ac.StructItem.float(),
+  -- ...
+})
+
+local frame = ac.readMemoryMappedFile('AcTools.CSP.Limited.ACPE.v1', FRAME)
+local shown = {}   -- last consistent snapshot
+
+function script.update(dt)
+  local seq = frame.sequence
+  if seq % 2 == 0 then                 -- writer not mid-update
+    -- copy the few fields we draw
+    shown.speed = frame.speed
+    -- ...
+    if frame.sequence ~= seq then return end   -- torn, keep previous
+  end
+end
+
+function script.windowMain(dt)
+  ui.text(string.format('%.0f km/h', shown.speed))
+end
+```
+
+`script.update` runs every frame even when no window is visible, so keep the
+copy small; `script.windowMain` only runs when the window is shown.
+
+## Work breakdown
+
+1. **`core/src/overlay/frame.rs`** — `OverlayFrame`, the version constant, and
+   a `pack(&AppState) -> OverlayFrame`. Pure function, fully unit-testable
+   without AC.
+2. **`core/src/overlay/shared_writer.rs`** — create/open the mapping and write
+   with the sequence lock. Windows via `CreateFileMappingW`, Linux via
+   `/dev/shm/<name>`.
+3. **`shm-bridge`** — one more entry in `ACC_FILES` with the overlay size.
+4. **Wire into the tick** — pack and write once per `tick()`, next to the
+   existing `overlay_manager.update`.
+5. **The Lua app** — `manifest.ini`, the struct declaration, drawing.
+6. **A layout conformance test** — see below. This is the one that stops the
+   whole thing silently breaking.
+7. **Packaging** — install the app into `apps/lua/`, using the `ac_paths`
+   discovery added in v0.3.1.
+8. **Retire `native_window.rs`** once the Lua app covers it, or keep it behind
+   `OverlayMode::NativeDesktop` for people without CSP.
+
+## Verification
+
+The hard part is that the two sides are written in different languages and
+compiled by different toolchains, so nothing catches a mismatch at build time.
+
+- **Layout conformance test (Rust).** Assert `size_of::<OverlayFrame>()` and
+  `offset_of!` for every field against constants written down in the test. Any
+  reordering or padding change fails immediately. This is the same technique
+  `ac_structs.rs` already uses to pin AC's own layout, and it caught a real bug
+  there.
+- **Generate the Lua declaration from the Rust struct** rather than maintaining
+  it by hand — a small build step or a test that emits the `ac.StructItem`
+  block and fails if the checked-in `.lua` differs. Two hand-maintained copies
+  of one layout will drift; the only question is when.
+- **Round-trip test.** Write a frame from Rust, read it back through the same
+  layout, compare. Runs on both platforms in CI, no AC required.
+- **Simulator.** Extend `tui/src/bin/simulator.rs` to also publish an overlay
+  frame, so the Lua app can be developed and demonstrated with no game running.
+- **In-game.** The only step that needs AC + CSP: install the app, confirm
+  values match the TUI, and check the frame cost with CSP's own Lua profiler.
+
+## Risks and open questions
+
+- **CSP is required.** A plain AC install has no Lua apps at all. The native
+  window path should stay for those users rather than being deleted.
+- **`__allowIO__` for apps is unconfirmed.** The `AcTools.CSP.Limited.` prefix
+  makes it moot, which is why the design uses it — but it should be confirmed
+  in-game before building on top of it.
+- **CSP is not installed on this machine**, and neither is AC (the Steam
+  directories exist but are empty). Everything above is from the published CSP
+  SDK sources, not from a running game. The layout rules and the two API
+  functions are quoted from source and are solid; the app-permission question
+  and the frame cost are not, and both need a real install to settle.
+- **Wine file-backed mapping visibility.** The bridge proves this works for
+  AC → app. The reverse direction (app writes, Wine process reads) uses the
+  same mechanism, but has not been exercised.
+
+## Sources
+
+- [acc-lua-sdk `ac_extras_connectmmf.lua`](https://github.com/ac-custom-shaders-patch/acc-lua-sdk/blob/main/common/ac_extras_connectmmf.lua)
+  — `ac.readMemoryMappedFile`, `ac.writeMemoryMappedFile`, the
+  `AcTools.CSP.Limited.` permission check
+- [acc-lua-sdk `ac_struct_item.lua`](https://github.com/ac-custom-shaders-patch/acc-lua-sdk/blob/main/common/ac_struct_item.lua)
+  — field reordering and `explicitOrder`
+- [acc-lua-sdk wiki: Lua apps](https://github.com/ac-custom-shaders-patch/acc-lua-sdk/wiki/Lua-apps)
+  — app folder layout, `script.update` / `script.windowMain`
+- `shm-bridge/src/file_mapping.rs` in this repository — the file-backed named
+  mapping the Linux path depends on

--- a/packaging/ac-pro-engineer.desktop
+++ b/packaging/ac-pro-engineer.desktop
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=AC Pro Engineer
+GenericName=Telemetry Analyzer
+Comment=Real-time telemetry and race engineering for Assetto Corsa
+# Terminal=false deliberately. The application opens its own terminal when it
+# has none, at the size its layout needs — letting the desktop environment
+# pick one gives whatever geometry that terminal defaults to, which is
+# usually 80x24 and too small for the UI.
+Terminal=false
+Exec=ac_pro_engineer
+Icon=ac-pro-engineer
+Categories=Game;
+Keywords=assetto;corsa;telemetry;sim;racing;
+StartupNotify=false

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -108,6 +108,30 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let args = AppArgs::parse();
 
+    // Started from a file manager or a desktop entry, there is no terminal to
+    // draw on: raw mode fails and the process dies before showing anything.
+    // Open one and run there instead. Must happen before the panic hook or
+    // any terminal setup, since neither applies to a process that is about to
+    // hand off to a child.
+    #[cfg(target_os = "linux")]
+    if platform::relaunch::needs_terminal() {
+        let exe = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("ac_pro_engineer"));
+        let forwarded: Vec<String> = std::env::args().skip(1).collect();
+        match platform::relaunch::relaunch_in_terminal(&exe, &forwarded) {
+            Ok(terminal) => {
+                info!("No terminal attached; relaunched in {terminal}");
+                return Ok(());
+            }
+            Err(reason) => {
+                // Carry on rather than exit. The application will fail
+                // visibly on stderr, which is more use than a silent exit,
+                // and a user who piped stdout deliberately still gets to run.
+                eprintln!("Could not open a terminal window ({reason}).");
+                eprintln!("Run this from a terminal instead: ac_pro_engineer");
+            }
+        }
+    }
+
     let overlay_mode = if args.overlay_test_d {
         OverlayMode::StandaloneTest
     } else if args.overlay_test_vr {

--- a/tui/src/platform.rs
+++ b/tui/src/platform.rs
@@ -1,2 +1,10 @@
 #[cfg(target_os = "linux")]
 pub mod linux;
+
+/// Relaunching into a terminal, for when the app is started from a file
+/// manager or a desktop entry rather than from a shell.
+///
+/// Linux only: on Windows the binary is built as a console subsystem
+/// application, so double-clicking it already opens a console window.
+#[cfg(target_os = "linux")]
+pub mod relaunch;

--- a/tui/src/platform/relaunch.rs
+++ b/tui/src/platform/relaunch.rs
@@ -1,0 +1,232 @@
+//! Re-launching the application inside a terminal emulator.
+//!
+//! A TUI double-clicked from a file manager has no terminal attached: stdout
+//! is a pipe or /dev/null, `crossterm` cannot enter raw mode, and the process
+//! either dies immediately or runs invisibly. From the user's point of view
+//! nothing happens at all.
+//!
+//! When there is no controlling terminal, the application starts one and runs
+//! itself inside it. The terminal is asked for a size large enough for the UI
+//! up front, so the layout is right on the first frame rather than after the
+//! user drags the window bigger.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Environment variable set on the child so it never tries to relaunch again.
+///
+/// A terminal emulator that starts but cannot run the command, or a stdout
+/// that is still not a tty for some reason we did not anticipate, would
+/// otherwise fork a new terminal forever.
+const GUARD_VAR: &str = "AC_PRO_ENGINEER_RELAUNCHED";
+
+/// Columns and rows requested from the terminal. Matches the size the UI
+/// asks for at startup, so nothing has to be resized after the fact.
+const COLS: u16 = 140;
+const ROWS: u16 = 40;
+
+/// How a given terminal emulator is asked for a size and a command.
+///
+/// The `-e`/`--` convention is not shared: some take the command as separate
+/// arguments after a flag, others take a single string. Getting this wrong
+/// means the terminal opens to a shell instead of the application, which is
+/// why each is spelled out rather than guessed at.
+struct TerminalSpec {
+    binary: &'static str,
+    /// Arguments before the command, including any size request.
+    args: &'static [&'static str],
+    /// Whether the size arguments use the `WxH` geometry form.
+    geometry: Option<GeometryStyle>,
+}
+
+enum GeometryStyle {
+    /// `-geometry 140x40`, as X11 clients have always taken it.
+    XGeometry,
+    /// `--geometry=140x40`.
+    LongGeometry,
+}
+
+/// Terminals to try, in order.
+///
+/// `x-terminal-emulator` first because on Debian derivatives it is the user's
+/// configured choice rather than ours. After that, the terminals most likely
+/// to be present on a gaming Linux box, ending with xterm, which is the one
+/// thing nearly always installed.
+const TERMINALS: &[TerminalSpec] = &[
+    TerminalSpec {
+        binary: "x-terminal-emulator",
+        args: &["-e"],
+        geometry: Some(GeometryStyle::XGeometry),
+    },
+    TerminalSpec {
+        binary: "konsole",
+        args: &["-e"],
+        geometry: None,
+    },
+    TerminalSpec {
+        binary: "alacritty",
+        args: &["-e"],
+        geometry: None,
+    },
+    TerminalSpec {
+        binary: "kitty",
+        args: &[],
+        geometry: None,
+    },
+    TerminalSpec {
+        binary: "wezterm",
+        args: &["start", "--"],
+        geometry: None,
+    },
+    TerminalSpec {
+        binary: "foot",
+        args: &[],
+        geometry: Some(GeometryStyle::LongGeometry),
+    },
+    TerminalSpec {
+        binary: "gnome-terminal",
+        args: &["--"],
+        geometry: Some(GeometryStyle::LongGeometry),
+    },
+    TerminalSpec {
+        binary: "xfce4-terminal",
+        args: &["-e"],
+        geometry: Some(GeometryStyle::LongGeometry),
+    },
+    TerminalSpec {
+        binary: "xterm",
+        args: &["-e"],
+        geometry: Some(GeometryStyle::XGeometry),
+    },
+];
+
+/// Whether this process should relaunch itself inside a terminal.
+///
+/// Only when there is no terminal to draw on, and only once — the guard
+/// variable stops a child that still has no tty from forking endlessly.
+pub fn needs_terminal() -> bool {
+    if std::env::var_os(GUARD_VAR).is_some() {
+        return false;
+    }
+    !std::io::IsTerminal::is_terminal(&std::io::stdout())
+}
+
+/// Extra arguments a terminal needs to open at the requested size.
+fn size_args(spec: &TerminalSpec) -> Vec<String> {
+    match spec.geometry {
+        Some(GeometryStyle::XGeometry) => {
+            vec!["-geometry".to_string(), format!("{COLS}x{ROWS}")]
+        }
+        Some(GeometryStyle::LongGeometry) => vec![format!("--geometry={COLS}x{ROWS}")],
+        // kitty, konsole, alacritty and wezterm all size from their own
+        // config or from the shell's SIGWINCH; the app's own resize request
+        // covers them, and passing a flag they do not know is fatal.
+        None => Vec::new(),
+    }
+}
+
+/// Start `exe` inside the first terminal emulator that works.
+///
+/// Returns the name of the terminal that accepted the job. `Err` means every
+/// candidate was missing or refused to start, in which case the caller should
+/// carry on and let the application fail visibly rather than silently.
+pub fn relaunch_in_terminal(exe: &PathBuf, args: &[String]) -> Result<&'static str, String> {
+    let mut attempts = Vec::new();
+
+    for spec in TERMINALS {
+        if which(spec.binary).is_none() {
+            continue;
+        }
+
+        let mut command = Command::new(spec.binary);
+        command.args(size_args(spec));
+        command.args(spec.args);
+        command.arg(exe);
+        command.args(args);
+        command.env(GUARD_VAR, "1");
+
+        match command.spawn() {
+            Ok(_) => return Ok(spec.binary),
+            Err(error) => attempts.push(format!("{}: {error}", spec.binary)),
+        }
+    }
+
+    if attempts.is_empty() {
+        Err("no terminal emulator found".to_string())
+    } else {
+        Err(attempts.join("; "))
+    }
+}
+
+/// Whether a binary is on PATH.
+///
+/// A three-line lookup rather than a dependency: this is the only thing the
+/// crate would use one for.
+fn which(binary: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(binary))
+        .find(|candidate| candidate.is_file())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_guard_variable_stops_a_relaunch_loop() {
+        // Safety: single-threaded test, and the variable is only read by
+        // `needs_terminal`.
+        unsafe { std::env::set_var(GUARD_VAR, "1") };
+        assert!(
+            !needs_terminal(),
+            "a process we already relaunched must never relaunch again"
+        );
+        unsafe { std::env::remove_var(GUARD_VAR) };
+    }
+
+    #[test]
+    fn x_geometry_terminals_get_the_traditional_flag() {
+        let spec = TerminalSpec {
+            binary: "xterm",
+            args: &["-e"],
+            geometry: Some(GeometryStyle::XGeometry),
+        };
+        assert_eq!(size_args(&spec), vec!["-geometry", "140x40"]);
+    }
+
+    #[test]
+    fn long_geometry_terminals_get_the_joined_form() {
+        let spec = TerminalSpec {
+            binary: "foot",
+            args: &[],
+            geometry: Some(GeometryStyle::LongGeometry),
+        };
+        assert_eq!(size_args(&spec), vec!["--geometry=140x40"]);
+    }
+
+    /// Passing a size flag a terminal does not understand is fatal, so the
+    /// ones that size themselves get nothing.
+    #[test]
+    fn terminals_without_a_geometry_flag_get_no_size_arguments() {
+        let spec = TerminalSpec {
+            binary: "kitty",
+            args: &[],
+            geometry: None,
+        };
+        assert!(size_args(&spec).is_empty());
+    }
+
+    #[test]
+    fn which_finds_a_binary_that_exists_and_not_one_that_does_not() {
+        assert!(which("sh").is_some(), "sh is on PATH everywhere");
+        assert!(which("definitely-not-a-real-binary-xyzzy").is_none());
+    }
+
+    /// The requested size has to match what the UI asks for, or the terminal
+    /// opens at one size and is immediately resized to another.
+    #[test]
+    fn the_requested_size_is_the_size_the_ui_wants() {
+        assert_eq!((COLS, ROWS), (140, 40));
+    }
+}


### PR DESCRIPTION
Two things.

**Linux double-click launch.** A TUI started from a file manager has no
terminal: stdout is a pipe, crossterm cannot enter raw mode, and the process
dies with an error nobody sees. It now opens a terminal emulator and runs
inside it at the size the layout needs, with a guard variable so a terminal
that cannot run the command cannot fork another forever. Ships a .desktop entry.

**Overlay design doc.** The current overlay is Windows-only (Linux gets
`None`) and the OpenXR provider is an empty stub. `docs/overlay-lua-plan.md`
records the design for a CSP Lua app that draws in-game while all computation
stays in Rust.

191 tests, clippy and fmt clean.