### PR TITLE
chore(licence): MIT to AGPL v3, with closed-source use by permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ All notable changes to this project will be documented in this file.
 **The point:** the Analysis tab drew what happened. It says **where** now, and
 how sure it is.
 
+### ⚖️ Licence: MIT → AGPL v3
+
+The project is licensed under the **GNU AGPL v3** from this release onward.
+Nothing changes for anyone using the application: it is free, it stays free,
+there is no account and no paid tier. What changes is what may be done with the
+source.
+
+- **Using it, and changing it for yourself, is unrestricted.** The licence
+  conditions passing a copy on, not what runs on your own machine.
+- **Publishing something built on it** now requires that your source is open
+  too, under the same licence, with this project credited. Under MIT it did not.
+- **Keeping your own source closed, or selling a product with this code inside
+  it**, needs written permission first — rgoshbbb@gmail.com. There is no price
+  list; terms are per case.
+- **v0.3.6 and every release before it stay MIT, permanently.** That grant
+  cannot be withdrawn, and `LICENSE-MIT-HISTORICAL` keeps its terms. The AGPL
+  applies to everything committed after `9ba92a3`.
+- **`shm-bridge` is untouched.** It is a fork of poljar's work and keeps its own
+  MIT licence.
+
+`LICENSING.md` is the plain-language version — what needs asking, what does not,
+and what happens to a closed product found shipping this code without asking.
+`CONTRIBUTING.md` covers the sign-off patches now need, and why.
+
 ### ✨ Added
 
 - **A CORNERS sub-tab: where the lap actually went.** Corners are found in the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing
+
+Patches, bug reports and telemetry captures from cars this has never seen are
+all welcome. `AGENTS.md` describes the codebase, `CLAUDE.md` how to work in it
+without repeating mistakes already made, and `docs/HANDOFF.md` where the current
+work stands. Read whichever is relevant before a large change; nothing here is
+about the code, only about the paperwork attached to it.
+
+## Sign off your commits
+
+Every commit needs a `Signed-off-by` line:
+
+```bash
+git commit -s -m "fix(engineer): the cold-tyre verdict waits for a measured temperature"
+```
+
+`-s` adds it from your git identity. The line certifies the Developer
+Certificate of Origin, reproduced below: that the code is yours to give.
+
+## And one more grant, which is not standard
+
+By signing off, you also agree that the maintainer may license your
+contribution **under the AGPL v3 and under a separate commercial licence**.
+
+This is worth explaining rather than burying, because it asks for something the
+DCO alone does not.
+
+AC Pro Engineer is offered two ways: free under the AGPL for anyone whose own
+work is open, and commercially for anyone who wants to build a closed product on
+it — see [LICENSING.md](LICENSING.md). The second only works if a single party
+holds the rights to relicense the whole thing. If one contribution arrives under
+the AGPL alone, the maintainer can no longer offer a commercial licence for the
+project without carving that contribution out or removing it — and in practice
+that means the contribution gets removed, which serves nobody.
+
+What you get in return is unchanged by any of it: your work stays under the
+AGPL, published, with your name on the commit, and you keep your copyright. You
+are granting an additional licence, not assigning ownership, and you may do
+anything you like with your own code elsewhere.
+
+If you would rather not grant that, say so in the pull request. A patch that
+fixes something real is still worth having, and it can usually be reworked or
+reimplemented; what cannot happen is it being merged quietly and discovered
+later.
+
+## Developer Certificate of Origin 1.1
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+## Before you open the pull request
+
+The suite has to be green on both targets, and the Lua harnesses take a second
+each:
+
+```bash
+cargo test --workspace
+```
+
+```bash
+cargo clippy --workspace --all-targets --target x86_64-pc-windows-gnu -- -D warnings
+```
+
+```bash
+luajit apps/lua/tests/run_overlay.lua
+```
+
+Commits follow Conventional Commits, in English, with bodies that say what was
+wrong, why it mattered and how it was verified. `AGENTS.md` has the examples.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ members = ["core", "tui", "shm-bridge", "tests_suite"]
 version = "0.3.6"
 edition = "2024"
 authors = ["Rgosh"]
+# AGPL from the commit after 9ba92a3 (v0.3.6 and earlier were MIT, and stay
+# MIT — that grant cannot be withdrawn; see LICENSE-MIT-HISTORICAL).
+# `shm-bridge` is deliberately not on this: it is a fork of poljar/shm-bridge
+# and keeps its own MIT licence.
+license = "AGPL-3.0-only"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,661 @@
-MIT License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) 2026 Rgosh
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/LICENSE-MIT-HISTORICAL
+++ b/LICENSE-MIT-HISTORICAL
@@ -1,0 +1,42 @@
+AC Pro Engineer was released under the MIT licence up to and including
+v0.3.6 — every commit through 9ba92a3df4b66da38989696c1755f1cf4ff02619,
+2026-08-11. From the commit that followed it the project is licensed under
+the GNU Affero General Public License v3.0; see LICENSE and LICENSING.md.
+
+This file is kept because that grant cannot be withdrawn. Anyone who
+obtained the project at v0.3.6 or earlier holds those versions under the
+terms below, permanently, and this is the copy of those terms. It says
+nothing about later versions, which the MIT licence never covered.
+
+`shm-bridge/` is a separate matter: it is a fork of Damir Jelić's
+shm-bridge and remains under the MIT licence today, not merely
+historically. Its own LICENCE sits in that folder.
+
+Below is that MIT licence exactly as it was published, single copyright
+line included. It named the project's maintainer; other contributors held
+and hold copyright in their own contributions, and every one of those
+contributions was made under these same terms. NOTICE lists them.
+
+----------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2026 Rgosh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,152 @@
+# Licensing
+
+AC Pro Engineer is licensed under the **GNU Affero General Public License,
+version 3** — `LICENSE` holds the text, `NOTICE` the two additional terms
+section 7 permits. This file is the plain-language version of what that means,
+because nobody should have to read a legal document to find out whether they
+may use a telemetry app.
+
+## The short version
+
+| What you want to do | What you need |
+|---|---|
+| Use it, race with it, tell people about it | Nothing. It is free. |
+| Read the source, learn from it, fork it | Nothing. |
+| Change it for yourself and never hand it to anyone | Nothing. [Really nothing.](#private-use-is-not-restricted-at-all) |
+| Build something on it and publish it **with source** under the AGPL | Nothing. Keep the notices, name the project. |
+| Build something on it and keep **your** source closed | Written permission, in advance — [ask](#asking-for-a-closed-source-exception). |
+| Sell a product with this code inside it | A commercial licence — [ask](#commercial-licensing). |
+
+## Private use is not restricted at all
+
+The AGPL puts conditions on **conveying** the software — handing a copy, or a
+program built from it, to somebody else. It puts none on what you do with your
+own copy on your own machine.
+
+So: rebuild it, rip out half of it, wire it into your own closed tooling, run it
+on your rig and your team's rigs, keep every line of it to yourself. No
+permission, no notification, no obligation. This is the one part of the licence
+that is genuinely absolute, and the fear of it is the most common
+misunderstanding of the AGPL.
+
+The line is reached when a copy leaves you, and section 13 draws it in one more
+place than the plain GPL does: if people **use** your version over a network —
+a hosted dashboard, a public relay, a service other drivers connect to — they
+count as having received it, and they are owed its source. Your own machines
+talking to each other are not other people.
+
+## Using it in an open project
+
+This is the case the licence is designed for and it needs no permission at all.
+Publish your work under the AGPL v3, keep the copyright notices from `NOTICE`
+intact, and credit AC Pro Engineer where your users can see it — the About
+screen, the README, the credits, whichever your project has.
+
+Two things the AGPL asks that the MIT licence did not:
+
+- **The source has to be available to the people who run it.** Not just to
+  whoever downloads a binary — if your work is reachable over a network,
+  section 13 says its users get the source too. A telemetry relay, a web
+  dashboard and a hosted engineer all count.
+- **Your whole work goes under the AGPL**, not only the files you copied.
+  That is what copyleft means, and it is the point: what grew out of this
+  stays open for the next person.
+
+## Asking for a closed-source exception
+
+The AGPL does not let you keep your source closed. There is no clause to read
+carefully here — it is simply not permitted, and no amount of separating
+processes or shipping the parts apart changes it.
+
+What is permitted is asking. **Write to rgoshbbb@gmail.com**, say:
+
+- what your project is and where it lives,
+- which parts of AC Pro Engineer you are using,
+- whether you are charging for it.
+
+Each request is decided on its own, and asking is not the same as being granted:
+what is being asked for is the one thing the licence otherwise refuses. Small,
+free and non-commercial work has the best case for it. Nothing is agreed until
+it is agreed in writing, naming your project — and a grant covers that project
+and no other.
+
+The one answer that is certain in advance is the answer to not asking.
+
+## Commercial licensing
+
+If you want to build a product on this core and sell it, that is welcome, and
+it needs a commercial licence: the right to ship the code inside a closed
+product, without the AGPL's obligations.
+
+There is no price list, because there is no standard case. What you are
+building, and how it is sold, decides what is reasonable — so describe both.
+**rgoshbbb@gmail.com.**
+
+What is not on the table is finding out afterwards. A closed product already
+shipping with this code inside it was never licensed to exist, and what applies
+to it is [further down](#what-happens-if-someone-does-not-ask).
+
+## What counts as using this code
+
+More than copy-and-paste, and this comes up often enough to answer here.
+
+**Covered.** Copied files, copied functions, a modified fork, and a
+**translation into another language** — including one an AI wrote. Copyright
+protects the expression, not the syntax: the structure, the order of
+operations, the decomposition into functions, the names, the comments, the
+thresholds and the constants all survive a translation to C++ or Python, and
+they are what identifies a copy. This project has unusually distinctive ones —
+the `OverlayFrame` layout and the order of its fields, the generated
+`frame_layout.lua`, `BRIDGE_PROTOCOL`, the eight advice slots, the specific
+verdict thresholds in `engineer.rs`. A machine translation carries every one of
+them across.
+
+**Not covered.** Ideas, algorithms and facts. Reading the README, understanding
+how a race engineer decides that a tyre is cold, and writing your own
+implementation without working from this source infringes nothing, in any
+language. That is how copyright works everywhere and it is not something a
+licence can change.
+
+## What happens if someone does not ask
+
+Section 8 of the AGPL is automatic: use the code outside the licence and the
+licence terminates by itself, with no notice and no court involved. From that
+moment there is no permission of any kind — not the closed-source part, all of
+it — and copying the work of a copyright holder without permission is
+infringement, with the usual consequences: takedown notices to whoever hosts or
+sells the product, and a claim for damages.
+
+Reinstatement is possible for a first violation that is cured, but the licence
+grants it only once, and only before the copyright holder has given notice.
+
+Separately from the licence, and as a matter of policy: **a project that has
+been found using this code outside its licence will not be sold a commercial
+one.** Asking first is cheaper than being found.
+
+## The name
+
+The licence covers the code. It grants nothing in the name **AC Pro Engineer**,
+the name **RaceEngineer**, or the project's icons and logo — `NOTICE` states
+this under section 7(e). Fork the code freely; ship it under a name of your
+own.
+
+## Versions before v0.3.7
+
+Everything published up to and including **v0.3.6** was MIT-licensed, and that
+grant cannot be withdrawn: those versions stay MIT for everyone who has them,
+permanently. `LICENSE-MIT-HISTORICAL` keeps those terms. The AGPL applies from
+the commit that followed `9ba92a3` onward, which is to say to v0.3.7 and every
+release after it.
+
+`shm-bridge/` is not affected at all. It is a fork of Damir Jelić's
+[shm-bridge](https://github.com/poljar/shm-bridge) and stays MIT-licensed,
+today and going forward, under its own `LICENSE`.
+
+## Contributing
+
+Patches are welcome, and they come with one requirement: a `Signed-off-by` line
+certifying the [Developer Certificate of Origin](CONTRIBUTING.md), plus
+agreement that the maintainer may also license your contribution commercially.
+`CONTRIBUTING.md` explains why — briefly, without it the commercial licence
+above becomes impossible to offer honestly, and that is the one way this project
+could ever pay for itself.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,57 @@
+AC Pro Engineer
+Copyright (c) 2026 Rgosh <rgoshbbb@gmail.com>
+Copyright (c) 2026 Maksym Vasylchuk <mvasilchuk@gmail.com>
+
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU Affero General Public License, version 3, as
+published by the Free Software Foundation. It is distributed WITHOUT ANY
+WARRANTY; see LICENSE for the full text and LICENSING.md for what it means
+in practice.
+
+
+ADDITIONAL TERMS UNDER SECTION 7 OF THE GNU AGPL v3
+
+These are the two additional terms section 7 permits. Both are the kinds
+the licence explicitly allows, so the result is still the AGPL and stays
+compatible with other AGPL-covered software.
+
+  a) Under section 7(b), you must preserve the copyright notices above and
+     this notice in every copy and every modified version you convey, and
+     any user-facing "about", credits or documentation screen must name
+     AC Pro Engineer and link to <https://github.com/Rgosh/ac-pro-engineer>.
+
+  b) Under section 7(e), no rights are granted in the names "AC Pro
+     Engineer" or "RaceEngineer", or in the project's logo and icons.
+     A modified version must be distributed under a different name. This
+     restricts the name, never the code: you may fork and ship freely,
+     under a name of your own.
+
+Removing either term from material you received is permitted by section 7
+only where that section allows it, and it does not remove the requirements
+of the licence itself.
+
+
+THIRD-PARTY COMPONENTS
+
+  shm-bridge/
+      A fork of shm-bridge by Damir Jelić <poljar@termina.org.uk>,
+      <https://github.com/poljar/shm-bridge>, under the MIT licence, with
+      later work by Maksym Vasylchuk and Rgosh. It remains MIT-licensed;
+      its licence sits in that folder and must travel with it.
+
+  Rust dependencies
+      Each carries its own licence, listed in Cargo.toml and reproduced in
+      full by `cargo license` or `cargo about`.
+
+  Assetto Corsa, Custom Shaders Patch and Content Manager
+      Not included, not modified and not affiliated with this project.
+      AC Pro Engineer reads the shared memory Assetto Corsa publishes and
+      installs a Lua app that Custom Shaders Patch loads; both are used
+      through their public interfaces.
+
+
+HISTORICAL LICENSING
+
+Releases up to and including v0.3.6 were published under the MIT licence.
+That grant stands for those versions and cannot be withdrawn; its terms are
+kept in LICENSE-MIT-HISTORICAL.

--- a/README.md
+++ b/README.md
@@ -1097,10 +1097,26 @@ tools do, and it is also a pattern some antivirus heuristics dislike.
 
 ## Licence and credits
 
-Released under the [MIT licence](LICENSE).
+Released under the [GNU AGPL v3](LICENSE). Free to use, free to fork, free to
+build on — provided what you build stays open. [LICENSING.md](LICENSING.md) is
+the plain-language version:
+
+- **Racing with it, reading it, forking it** — nothing to do, it is free.
+- **Changing it for yourself and never passing it on** — nothing to do either.
+  The licence conditions distribution, not what runs on your own rig.
+- **Building on it and publishing the source** under the AGPL — nothing to ask.
+  Keep the notices, credit the project.
+- **Keeping your own source closed** — needs written permission, in advance:
+  <rgoshbbb@gmail.com>.
+- **Selling a product with this inside it** — a commercial licence, same
+  address. Terms per case; there is no price list.
+
+Versions up to and including **v0.3.6 were MIT** and stay MIT; that grant
+cannot be withdrawn. The AGPL applies from v0.3.7 onward.
 
 `shm-bridge` began as [Damir Jelić's](https://github.com/poljar) work on bridging
-Wine shared memory and is used and extended here under the same terms.
+Wine shared memory and is used and extended here **under its own MIT licence**,
+which this project's change does not touch.
 
 Built with [ratatui](https://ratatui.rs), [tokio](https://tokio.rs) and
 [Custom Shaders Patch](https://acstuff.ru/patch/). Not affiliated with Kunos

--- a/README.txt
+++ b/README.txt
@@ -59,6 +59,19 @@ exclusions. The whole thing is open source and can be built from the
 repository below.
 
 
+[ LICENCE ]
+
+Free software under the GNU AGPL v3 — use it, fork it, build on it. Change
+it for yourself and nothing is asked of you at all. Pass your version on
+and the one condition is that it stays open, with the project credited.
+
+Keeping your own source closed, or selling a product with this code inside
+it, needs written permission first: rgoshbbb@gmail.com.
+
+LICENSE, NOTICE and LICENSING.md in the bundle have the detail.
+shm-bridge.exe is a separate piece and stays under its own MIT licence.
+
+
 [ LINKS & SUPPORT ]
 
 Source and issues:

--- a/assets/frontends/csp-panel/ac_pro_engineer.lua
+++ b/assets/frontends/csp-panel/ac_pro_engineer.lua
@@ -1,3 +1,11 @@
+-- Copyright (c) 2026 Rgosh and contributors.
+--
+-- Free software under the GNU Affero General Public License, version 3, with
+-- the additional terms in NOTICE, and NO WARRANTY. This copy sits in the game
+-- folder where it is easy to take; taking it is fine, and what the licence
+-- asks in return is in LICENSING.md next to the application. Closed-source use
+-- needs written permission — rgoshbbb@gmail.com.
+--
 -- AC Pro Engineer — the in-game panel.
 --
 -- This script computes nothing. Every value it draws was calculated by the

--- a/build_release.bat
+++ b/build_release.bat
@@ -88,6 +88,14 @@ if exist "README.txt" (
     echo WARNING: README.txt not found in the root directory!
 )
 
+REM The licence, and the two files it points at. README.txt tells the reader
+REM they are "in this folder", and the Windows bundle used to ship without
+REM them — a licence nobody received is a licence nobody can follow.
+for %%d in (README.md CHANGELOG.md LICENSE LICENSE-MIT-HISTORICAL NOTICE LICENSING.md) do (
+    if exist "%%d" copy /Y "%%d" "%BUNDLE_DIR%\" >nul
+)
+echo   - Docs and licence files copied to the bundle.
+
 echo.
 echo Zipping All-in-One release...
 pushd "%RELEASE_DIR%"

--- a/build_release.sh
+++ b/build_release.sh
@@ -81,7 +81,7 @@ fi
 
 # Everything needed when the automatic path does not work, in the bundle rather
 # than in a document nobody opens until the game is already broken.
-for doc in README.md CHANGELOG.md LICENSE; do
+for doc in README.md CHANGELOG.md LICENSE LICENSE-MIT-HISTORICAL NOTICE LICENSING.md; do
     if [ -f "${doc}" ]; then
         cp "${doc}" "${BUNDLE_DIR}/"
     fi

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,6 +7,7 @@ description = "Core telemetry and setup logic for AC Pro Engineer"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,11 @@
+// AC Pro Engineer — telemetry and race engineering for Assetto Corsa.
+// Copyright (c) 2026 Rgosh and contributors.
+//
+// This program is free software under the GNU Affero General Public License,
+// version 3, with the additional terms in NOTICE. It comes with NO WARRANTY.
+// LICENSE has the text; LICENSING.md says what it means, including how to ask
+// for a closed-source exception. Versions up to v0.3.6 were MIT and stay MIT.
+
 pub mod games;
 
 // Where these two used to live. Kept as re-exports so the move into `games/`

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -27,8 +27,8 @@ unix-archive = ".tar.gz"
 # The prefix setup, which is what stands between a fresh Linux machine and CSP
 # loading at all.
 #
-# Deliberately just this one file. Two things that look like they belong here
-# do not:
+# The prefix setup and the two licence files dist does not know about. Two
+# things that look like they belong here do not:
 #
 # * **The Lua panel.** Its folder must be named `ac_pro_engineer` for CSP to
 #   find its entry point, and that is also the name of the Linux binary — one
@@ -38,9 +38,14 @@ unix-archive = ".tar.gz"
 #   is the one shaped for this build's frame.
 # * **CHANGELOG.md, README.md, LICENSE.** dist adds these itself via
 #   auto-includes; naming them again is the same collision by another route.
+#   `LICENSE-MIT-HISTORICAL` is caught by the same rule and is likewise absent
+#   here. `NOTICE` and `LICENSING.md` are not — auto-includes cover only
+#   README, (UN)LICENSE and CHANGELOG/RELEASES — so they are named below. They
+#   have to travel: NOTICE carries the section 7 terms the licence refers to,
+#   and without it the archive ships a licence that points at a missing file.
 #
 # There are no fonts here and there cannot be. The desktop side is a terminal
 # program and uses the terminal's font; the panel draws through CSP's
 # DirectWrite. The font step is `corefonts` inside the Proton prefix, which is
 # what proton-setup.sh runs.
-include = ["packaging/proton-setup.sh"]
+include = ["packaging/proton-setup.sh", "NOTICE", "LICENSING.md"]

--- a/shm-bridge/Cargo.toml
+++ b/shm-bridge/Cargo.toml
@@ -2,6 +2,9 @@
 name = "shm-bridge"
 authors = ["Damir Jelić <poljar@termina.org.uk>", "Maksym Vasylchuk <mvasilchuk@gmail.com>"]
 description = "Shared memory bridge for Wine/Proton and Linux apps."
+# Not the workspace's AGPL. This crate is a fork of poljar/shm-bridge, whose
+# MIT terms are not this project's to change; see shm-bridge/LICENSE.
+license = "MIT"
 version.workspace = true
 edition.workspace = true
 repository = "https://github.com/Rgosh/ac-pro-engineer.git"

--- a/site/index.html
+++ b/site/index.html
@@ -38,7 +38,7 @@
   "applicationCategory":"GameApplication",
   "applicationSubCategory":"Sim racing telemetry and race engineering",
   "operatingSystem":"Windows, Linux, SteamOS",
-  "license":"https://opensource.org/licenses/MIT",
+  "license":"https://www.gnu.org/licenses/agpl-3.0.html",
   "isAccessibleForFree":true,
   "offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},
   "url":"https://proengineer.app/",
@@ -1204,7 +1204,7 @@
         <tbody>
           <tr>
             <td>Cost</td>
-            <td style="color:var(--good)">free, MIT</td>
+            <td style="color:var(--good)">free, AGPL</td>
             <td>free tier; $7.99–$19.99/mo</td>
             <td>subscription</td>
             <td>free tier; ~€3.90/mo</td>
@@ -1353,8 +1353,23 @@ cargo run --release</pre>
     <h2><span class="tw" style="--n:9">QUESTIONS</span></h2>
 
     <details class="fold" open>
-      <summary>Is it free? <span class="blurb">Yes, MIT</span></summary>
+      <summary>Is it free? <span class="blurb">Yes, AGPL v3</span></summary>
       <div class="fold-body"><p class="lede">Free and open source. No account, no subscription, and no telemetry collected about you.</p></div>
+    </details>
+
+    <details class="fold">
+      <summary>Can I use the code in my own project?</summary>
+      <div class="fold-body"><p class="lede">
+        Yes. Change it for yourself and nothing at all is asked of you — the licence
+        conditions passing a copy on, not what runs on your own rig. Publish something
+        built on it and the one condition is that your source is open too, under the
+        same <a href="https://github.com/Rgosh/ac-pro-engineer/blob/main/LICENSE">AGPL v3</a>,
+        with this project credited. Keeping your own source closed, or selling a product
+        with this code inside it, needs written permission first —
+        <a href="mailto:rgoshbbb@gmail.com">rgoshbbb@gmail.com</a>. The
+        <a href="https://github.com/Rgosh/ac-pro-engineer/blob/main/LICENSING.md">licensing page</a>
+        says it in full.
+      </p></div>
     </details>
 
     <details class="fold">
@@ -1428,7 +1443,7 @@ cargo run --release</pre>
         <svg class="mark big" viewBox="0 0 512 512" aria-hidden="true" focusable="false"><rect width="512" height="512" rx="113" fill="#0a0a0f"/><path d="M118 118 L262 256 L118 394" fill="none" stroke="#00b4ff" stroke-width="44" stroke-linecap="round" stroke-linejoin="round"/><rect x="307" y="338" width="87" height="44" rx="14" fill="#ffa500"/></svg>
         <div>
           <span class="prompt">$</span> ac_pro_engineer --version<br>
-          <span style="color:var(--dim)">Free software, MIT licensed. Built in Rust.</span>
+          <span style="color:var(--dim)">Free software, <a href="https://github.com/Rgosh/ac-pro-engineer/blob/main/LICENSING.md">AGPL v3</a>. Built in Rust.</span>
         </div>
       </div>
       <div>

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/Rgosh/ac-pro-engineer.git"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -1,3 +1,11 @@
+// AC Pro Engineer — telemetry and race engineering for Assetto Corsa.
+// Copyright (c) 2026 Rgosh and contributors.
+//
+// This program is free software under the GNU Affero General Public License,
+// version 3, with the additional terms in NOTICE. It comes with NO WARRANTY.
+// LICENSE has the text; LICENSING.md says what it means, including how to ask
+// for a closed-source exception. Versions up to v0.3.6 were MIT and stay MIT.
+
 use ac_core::config::Language;
 use ac_core::updater::UpdateStatus;
 // Only the Linux startup path reaches into `platform`.


### PR DESCRIPTION
## What this is

The project moves from MIT to the **GNU AGPL v3**, from this branch onward, with closed-source and commercial use available by written permission.

MIT let anyone take this, close it and sell it, and the author would never learn it happened. The value of the project is mostly still ahead of it — corner analysis, driver-versus-car, the confidence model — and this is the point at which to decide what happens to that work.

## The rules, as they now read

| What you want to do | What you need |
|---|---|
| Use it, race with it | Nothing. Free, no account, no paid tier. |
| Change it for yourself and never pass it on | Nothing at all — the licence conditions conveying, not computing. |
| Publish something built on it, with source, under the AGPL | Nothing to ask. Keep the notices, credit the project. |
| Keep your own source closed | Written permission, in advance. |
| Sell a product with this code inside it | A commercial licence. Terms per case; deliberately no price list. |

Asking is not the same as being granted, and `LICENSING.md` says so: the request is for the one thing the licence otherwise refuses. What is certain in advance is only the answer to *not* asking — section 8 terminates the licence automatically, and a project found using this outside its licence will not be sold a commercial one.

## Not relicensed, deliberately

- **v0.3.6 and everything before it.** That MIT grant cannot be withdrawn. `LICENSE-MIT-HISTORICAL` keeps its terms verbatim — single copyright line included, diffed against the file it replaces. The AGPL applies from the commit after `9ba92a3`.
- **`shm-bridge/`.** A fork of [poljar/shm-bridge](https://github.com/poljar/shm-bridge); those MIT terms are not this project's to change. Its crate now says `license = "MIT"` explicitly instead of inheriting the workspace's.

## New files

- `LICENSE` — AGPL-3.0 verbatim from gnu.org, so GitHub's detector picks it up and the README badge corrects itself.
- `NOTICE` — copyright holders, the two additional terms under section 7, third-party components.
- `LICENSING.md` — the plain-language version, including what counts as using this code: a translation into another language, **including one an AI wrote**, is a derivative work; ideas and algorithms are not.
- `LICENSE-MIT-HISTORICAL`, `CONTRIBUTING.md`.

Section 7 adds exactly two terms, both of the kinds that section permits, so this stays compatible with other AGPL software: **7(b)** preserves attribution, **7(e)** withholds the name — fork the code freely, ship it under a name of your own.

## Why CONTRIBUTING.md asks for more than a DCO

Dual licensing only works if one party can relicense the whole thing. One AGPL-only contribution merged quietly makes the commercial licence impossible to offer honestly, and the moment to say that is before the pull request. Contributors keep their copyright; they grant an additional licence, not ownership.

## Incidental fixes found on the way

- The manifests had **no `license` field at all** — the packages had been publishing with none.
- `build_release.bat` had never copied even `LICENSE` into the bundle. It now carries the licence files, as `build_release.sh` does; `dist-workspace.toml` names `NOTICE` and `LICENSING.md`, which `auto-includes` does not cover (it handles only README, (UN)LICENSE and CHANGELOG/RELEASES).

## Reviewer notes

Every claim of "MIT" is corrected in `README.md`, `README.txt` and the site — including the JSON-LD `license` field the search engines read, the comparison table, the FAQ and the footer, plus a new FAQ entry on using the code.

**Two things this PR cannot do and that are still owed:**

1. **Maksym Vasylchuk's written consent** (~40 commits in `core/`). Legally the relicensing works without it — his contributions came in under MIT, which permits sublicensing — but one email removes the only scenario where the dual-licence model collapses.
2. **A dependency audit** before the first commercial licence is sold: `cargo deny` with GPL/LGPL/AGPL denied in the graph. One copyleft crate would make a proprietary offering impossible.

## Verification

- `cargo test --workspace` — green, 253 + 59 + 62.
- `cargo clippy --workspace --all-targets --target x86_64-pc-windows-gnu -- -D warnings` — clean.
- `luajit apps/lua/tests/run_overlay.lua` — all OK, including the panel's new licence header.

Two bridge tests failed on the first run: a stale 0.3.5 `shm-bridge.exe` in `target/` against a 0.3.6 workspace. Pre-existing, not from this change; rebuilding the bridge fixed both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
