### PR TITLE
fix(site): the licensing answer exists for search engines too

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -90,6 +90,14 @@
     },
     {
       "@type": "Question",
+      "name": "Can I use the code in my own project?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Change it for yourself and nothing at all is asked of you — the licence conditions passing a copy on, not what runs on your own rig. Publish something built on it and the one condition is that your source is open too, under the same AGPL v3, with this project credited. Keeping your own source closed, or selling a product with this code inside it, needs written permission first: rgoshbbb@gmail.com."
+      }
+    },
+    {
+      "@type": "Question",
       "name": "Does it work on Linux or a Steam Deck?",
       "acceptedAnswer": {
         "@type": "Answer",


### PR DESCRIPTION
Follow-up to #10.

The licence change added a visible FAQ entry — *"Can I use the code in my own project?"* — and did not add it to the `FAQPage` JSON-LD block. The visible list and the structured data had matched question for question until now, and the one that went missing is the one people arrive asking. The answer that would have been quoted straight into a search result was the only answer not offered there.

Both sides list nine questions again, in the same order. Verified by parsing the block rather than by eye:

```
0 SoftwareApplication
1 FAQPage 9
   - Is it free?
   - Can I use the code in my own project?
   - Does it work on Linux or a Steam Deck?
   ...
2 WebSite
```

Site-only; no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
